### PR TITLE
 Basic address schema and migrations 

### DIFF
--- a/apps/core/lib/core/snitch/address.ex
+++ b/apps/core/lib/core/snitch/address.ex
@@ -11,27 +11,34 @@ defmodule Core.Snitch.Address do
 
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   schema "snitch_addresses" do
-    field :first_name, :string
-    field :last_name, :string
-    field :address_line1, :string
-    field :address_line2, :string
-    field :city, :string
-    field :zip_code, :string
-    field :phone, :string
-    field :alternate_phone, :string
+    field(:first_name, :string)
+    field(:last_name, :string)
+    field(:address_line_1, :string)
+    field(:address_line_2, :string)
+    field(:city, :string)
+    field(:zip_code, :string)
+    field(:phone, :string)
+    field(:alternate_phone, :string)
 
     # has_one :state, State
     # has_one :country, Country
     timestamps()
   end
 
+  # state_id country_id)a
+  @required_fields ~w(first_name last_name address_line_1 city zip_code)a
+  @optional_fields ~w(phone alternate_phone)a
+
+  @spec changeset(__MODULE__.t(), map()) :: Ecto.Changeset.t()
   def changeset(address, params \\ %{}) do
     address
-    |> cast(params, ~w(first_name last_name address_line_1 city zip_code))
-    |> validate_required(~w(first_name last_name address_line_1 city zip_code))
+    |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
     |> validate_length(:address_line_1, min: 10)
-    |> validate_length(:address_line_2, min: 10)
+
     # |> foreign_key_constraint(:state_id, Core.Snitch.State)
     # |> foreign_key_constraint(:country_id, Core.Snitch.Country)
   end

--- a/apps/core/lib/core/snitch/address.ex
+++ b/apps/core/lib/core/snitch/address.ex
@@ -1,0 +1,38 @@
+defmodule Core.Snitch.Address do
+  @moduledoc """
+  Models an Address
+
+  An `Address` must contain a reference to `Core.Snitch.Country` and only if the
+  country has states a reference to a `Core.Snitch.State`. This means some
+  Addresses might not have a State.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "snitch_addresses" do
+    field :first_name, :string
+    field :last_name, :string
+    field :address_line1, :string
+    field :address_line2, :string
+    field :city, :string
+    field :zip_code, :string
+    field :phone, :string
+    field :alternate_phone, :string
+
+    # has_one :state, State
+    # has_one :country, Country
+    timestamps()
+  end
+
+  def changeset(address, params \\ %{}) do
+    address
+    |> cast(params, ~w(first_name last_name address_line_1 city zip_code))
+    |> validate_required(~w(first_name last_name address_line_1 city zip_code))
+    |> validate_length(:address_line_1, min: 10)
+    |> validate_length(:address_line_2, min: 10)
+    # |> foreign_key_constraint(:state_id, Core.Snitch.State)
+    # |> foreign_key_constraint(:country_id, Core.Snitch.Country)
+  end
+end

--- a/apps/core/priv/repo/migrations/20180212065208_create_address.exs
+++ b/apps/core/priv/repo/migrations/20180212065208_create_address.exs
@@ -3,14 +3,14 @@ defmodule Core.Repo.Migrations.CreateAddress do
 
   def change do
     create table(:snitch_addresses) do
-      add(:first_name, :string)
-      add(:last_name, :string)
-      add(:address_line1, :string, null: false)
-      add(:address_line2, :string)
-      add(:city, :string)
-      add(:zip_code, :string, null: false)
-      add(:phone, :string)
-      add(:alternate_phone, :string)
+      add :first_name, :string, null: false
+      add :last_name, :string, null: false
+      add :address_line_1, :string, null: false
+      add :address_line_2, :string
+      add :city, :string
+      add :zip_code, :string, null: false
+      add :phone, :string
+      add :alternate_phone, :string
       timestamps()
     end
   end

--- a/apps/core/priv/repo/migrations/20180212065208_create_address.exs
+++ b/apps/core/priv/repo/migrations/20180212065208_create_address.exs
@@ -1,0 +1,17 @@
+defmodule Core.Repo.Migrations.CreateAddress do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_addresses) do
+      add(:first_name, :string)
+      add(:last_name, :string)
+      add(:address_line1, :string, null: false)
+      add(:address_line2, :string)
+      add(:city, :string)
+      add(:zip_code, :string, null: false)
+      add(:phone, :string)
+      add(:alternate_phone, :string)
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
+ Do we really need the following fields?
  * `first_name`
  * `last_name`
+ Should `address_line_2` be a "required field"?
+ Min. length of `address_line_1` is set to 10. Is that ok?

This feature is **blocked by `State`, `Country`**.