### PR TITLE
Set up Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 elixir:
   - 1.5.3
-  - 1.6.1
   - 1.6.2
 otp_release:
   - 20.2
@@ -12,3 +11,6 @@ before_install:
   - mix deps.get
 script:
   - mix test
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ elixir:
   - 1.5.3
   - 1.6.1
   - 1.6.2
+otp_release:
+  - 20.2
+  - 19.3
 before_install:
   - mix local.hex --force
   - mix local.rebar --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: elixir
+elixir:
+  - 1.5.3
+  - 1.6.1
+  - 1.6.2
+before_install:
+  - mix local.hex --force
+  - mix local.rebar --force
+  - mix deps.get
+script:
+  - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ elixir:
   - 1.6.2
 otp_release:
   - 20.2
-  - 19.3
 before_install:
   - mix local.hex --force
   - mix local.rebar --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - mix local.rebar --force
   - mix deps.get
 script:
-  - mix test
+  - mix coveralls.travis
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - mix local.rebar --force
   - mix deps.get
 script:
-  - mix coveralls.travis
+  - mix coveralls.travis --umbrella
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Snitch
 
+[![Inline docs](http://inch-ci.org/github/aviabird/snitch.svg)](http://inch-ci.org/github/aviabird/snitch)
+
 An umbrella application
 
 Core: Has all the main schemas

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Snitch
 
+[![Build Status](https://travis-ci.org/aviabird/snitch.svg?branch=develop)](https://travis-ci.org/aviabird/snitch)
+[![Coverage Status](https://coveralls.io/repos/github/aviabird/snitch/badge.svg?branch=travis%2Finit)](https://coveralls.io/github/aviabird/snitch?branch=travis%2Finit)
 [![Inline docs](http://inch-ci.org/github/aviabird/snitch.svg)](http://inch-ci.org/github/aviabird/snitch)
 
 An umbrella application

--- a/apps/core/.gitignore
+++ b/apps/core/.gitignore
@@ -3,7 +3,8 @@
 /db
 /deps
 /*.ez
-/doc
+/doc*
+/cover
 # Generated on crash by the VM
 erl_crash.dump
 

--- a/apps/core/config/config.exs
+++ b/apps/core/config/config.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :core, ecto_repos: [Core.Repo]
 config :worldly, :data_path, Path.join(Mix.Project.build_path(), "lib/worldly/priv/data")
+
 import_config "#{Mix.env()}.exs"

--- a/apps/core/config/docs.exs
+++ b/apps/core/config/docs.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :core, Core.Repo, adapter: Ecto.Adapters.Postgres

--- a/apps/core/config/test.exs
+++ b/apps/core/config/test.exs
@@ -8,3 +8,5 @@ config :core, Core.Repo,
   database: "core_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :logger, level: :info

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -52,7 +52,7 @@ defmodule Core.Mixfile do
       {:excoveralls, "~> 0.8", only: :test},
       {:ex_machina, "~> 2.1", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:inch_ex, "~> 0.5.6", only: :docs},
+      {:inch_ex, "~> 0.5.6", only: [:docs, :dev]},
       {:excountries, "~> 0.0.1"},
       {:yamerl, github: "yakaz/yamerl", override: true},
       {:worldly, github: "martide/worldly"},

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -14,8 +14,7 @@ defmodule Core.Mixfile do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.html": :test]
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -53,6 +53,7 @@ defmodule Core.Mixfile do
       {:excoveralls, "~> 0.8", only: :test},
       {:ex_machina, "~> 2.1", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
+      {:inch_ex, "~> 0.5.6", only: :docs},
       {:excountries, "~> 0.0.1"},
       {:yamerl, github: "yakaz/yamerl", override: true},
       {:worldly, github: "martide/worldly"},

--- a/apps/help/.gitignore
+++ b/apps/help/.gitignore
@@ -8,7 +8,7 @@
 /deps/
 
 # Where 3rd-party dependencies like ExDoc output generated docs.
-/doc/
+/doc*
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,9 @@ defmodule Snitch.Mixfile do
     [
       apps_path: "apps",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [coveralls: :test, "coveralls.travis": :test, "coveralls.html": :test]
     ]
   end
 
@@ -17,6 +19,7 @@ defmodule Snitch.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:excoveralls, "~> 0.8", only: :test},
       {:inch_ex, "~> 0.5.6", only: :docs}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Snitch.Mixfile do
     [
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test},
-      {:inch_ex, "~> 0.5.6", only: :docs}
+      {:inch_ex, "~> 0.5.6", only: [:docs, :dev]}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,9 @@ defmodule Snitch.Mixfile do
   #
   # Run "mix help deps" for examples and options.
   defp deps do
-    []
+    [
+      {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:inch_ex, "~> 0.5.6", only: :docs}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -22,6 +22,7 @@
   "hackney": {:hex, :hackney, "1.3.2", "43bd07ab88753f5e136e38fddd2a09124bee25733b03361eeb459d0173fc17ab", [:make, :rebar], [{:idna, "~> 1.0.2", [hex: :idna, repo: "hexpm", optional: false]}, {:ssl_verify_hostname, "~> 1.0.5", [hex: :ssl_verify_hostname, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.7.5", "7f4a1dc1245f6a4a7d944786b75a44c94056bd54830299229e4b57fd75cb9daa", [:mix], [{:hackney, "~> 1.3.1", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "1.0.3", "d456a8761cad91c97e9788c27002eb3b773adaf5c893275fc35ba4e3434bbd9b", [:rebar3], [], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},


### PR DESCRIPTION
Builds run on [Travis](https://travis-ci.org/aviabird/snitch/), and take about 3 mins to run. The tests are fast, it's the fetching and compiling that's slow.

Coverage report generated using [excoveralls](https://www.github.com/parroty/excoveralls) and hosted on [coveralls.io](https://coveralls.io/github/aviabird/snitch). We are at 42% already!

Inch CI makes [reports](https://inch-ci.org/github/aviabird/snitch) on how well we've documented stuff. You can run `mix inch` at the repo root to not only locally grade your documentation skills :wink:, but `inch` will also suggest which modules/functions need some more love and attention from you. Works better if your terminal is configured with an emoji-aware font like [powerline](https://github.com/powerline/fonts)