### PR TITLE
Switch to CodeCov and speed up build

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,22 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default: on
+    patch:
+      default: on
+    changes:
+      default: on
+
+codecov:
+  branch: develop
+
+comment:
+  layout: "header, reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes

--- a/.scripts/inch_report.sh
+++ b/.scripts/inch_report.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ev
+
+if [ $TRAVIS_PULL_REQUEST = false ]; then
+    env MIX_ENV=docs mix deps.get
+    env MIX_ENV=docs mix inch.report
+else
+    echo "Skipping Inch report because this is a PR build"
+fi

--- a/.scripts/inch_report.sh
+++ b/.scripts/inch_report.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-set -ev
-
+set -e
+bold=$(tput bold)
+purple='\e[106m'
+normal=$(tput sgr0)
 allowed_branches="^(master)|(develop)$"
 
+echo -e "${bold}${purple}"
 if [ $TRAVIS_PULL_REQUEST = false ]; then
     if [[ $TRAVIS_BRANCH =~ $allowed_branches ]]; then
         env MIX_ENV=docs mix deps.get
@@ -14,3 +17,4 @@ if [ $TRAVIS_PULL_REQUEST = false ]; then
 else
     echo "Skipping Inch CI report because this is a PR build"
 fi
+echo -e "${normal}"

--- a/.scripts/inch_report.sh
+++ b/.scripts/inch_report.sh
@@ -2,9 +2,15 @@
 
 set -ev
 
+allowed_branches="^(master)|(develop)$"
+
 if [ $TRAVIS_PULL_REQUEST = false ]; then
-    env MIX_ENV=docs mix deps.get
-    env MIX_ENV=docs mix inch.report
+    if [[ $TRAVIS_BRANCH =~ $allowed_branches ]]; then
+        env MIX_ENV=docs mix deps.get
+        env MIX_ENV=docs mix inch.report
+    else
+        echo "Skipping Inch CI report because this branch does not match on /$allowed_branches/"
+    fi
 else
-    echo "Skipping Inch report because this is a PR build"
+    echo "Skipping Inch CI report because this is a PR build"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,16 @@ script:
   - set -e
   - MIX_ENV=test mix format --check-formatted
   - set +e
-  - mix coveralls.travis --umbrella
+  - mix coveralls.json --umbrella
 after_script:
+  - bash <(curl -s https://codecov.io/bash)
   - bash .scripts/inch_report.sh
 
 matrix:
   include:
   - elixir: "1.5.3"
     script:
-      - mix coveralls.travis --umbrella
+      - mix coveralls.json --umbrella
   - elixir: "1.6.2"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: elixir
-elixir:
-  - 1.5.3
-  - 1.6.2
+elixir: 1.6.2
 otp_release:
   - 20.2
 before_install:
-  - mix local.hex --force
-  - mix local.rebar --force
-  - mix deps.get
+  - echo $TRAVIS_PULL_REQUEST
 script:
-  - mix coveralls.travis --umbrella
-after_script:
-  - mix deps.get --only docs
-  - MIX_ENV=docs mix inch.report
+  - echo "done"
+
+branches:
+  only:
+    - master
+    - develop
+    - /^feature[\/-].*/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^travis.*/
+
+notifications:
+  email:
+    recipients:
+      - ananya95+travis@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,6 @@ matrix:
       - mix coveralls.travis --umbrella
   - elixir: "1.6.2"
 
-branches:
-  only:
-    - master
-    - develop
-    - /^feature[\/-].*/
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
-    - /^travis.*/
-
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: elixir
-elixir: 1.6.2
+
 otp_release:
   - 20.2
 before_install:
-  - echo $TRAVIS_PULL_REQUEST
+  - mix local.hex --force
+  - mix local.rebar --force
+  - mix deps.get
 script:
-  - echo "done"
+  - set -e
+  - MIX_ENV=test mix format --check-formatted
+  - set +e
+  - mix coveralls.travis --umbrella
+after_script:
+  - bash .scripts/inch_report.sh
+
+matrix:
+  include:
+  - elixir: "1.5.3"
+    script:
+      - mix coveralls.travis --umbrella
+  - elixir: "1.6.2"
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snitch
 
 [![Build Status](https://travis-ci.org/aviabird/snitch.svg?branch=develop)](https://travis-ci.org/aviabird/snitch)
-[![Coverage Status](https://coveralls.io/repos/github/aviabird/snitch/badge.svg?branch=travis%2Finit)](https://coveralls.io/github/aviabird/snitch?branch=travis%2Finit)
+[![codecov](https://codecov.io/gh/aviabird/snitch/branch/develop/graph/badge.svg)](https://codecov.io/gh/aviabird/snitch)
 [![Inline docs](http://inch-ci.org/github/aviabird/snitch.svg)](http://inch-ci.org/github/aviabird/snitch)
 
 An umbrella application

--- a/apps/core/lib/core/snitch/data/model/model.ex
+++ b/apps/core/lib/core/snitch/data/model/model.ex
@@ -13,7 +13,7 @@ defmodule Core.Snitch.Data.Model do
       alias Helpers.QueryHelper, as: QH
 
       alias Core.Snitch.Data.{Schema, Model}
-      
+
       use Core.Snitch.Data.Model.{
         Stock
       }

--- a/apps/core/lib/core/snitch/domain/domain.ex
+++ b/apps/core/lib/core/snitch/domain/domain.ex
@@ -3,7 +3,7 @@ defmodule Core.Snitch.Domain do
     Interface for handling Business related logics.
     Uses Models for DB related queries.
   """
-  
+
   defmacro __using__(_) do
     quote do
       alias Core.Snitch.{Data.Model, Data.Schema, Domain, Repo}

--- a/apps/core/lib/core/snitch/domain/stock/inventory.ex
+++ b/apps/core/lib/core/snitch/domain/stock/inventory.ex
@@ -2,6 +2,6 @@ defmodule Core.Snitch.Domain.Stock.Inventory do
   @moduledoc """
     Interface for handling inventory related business logic
   """
-  
+
   use Core.Snitch.Domain
 end

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -9,12 +9,13 @@ defmodule Core.Mixfile do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls],
+      docs: docs()
     ]
   end
 
@@ -47,16 +48,34 @@ defmodule Core.Mixfile do
       {:comeonin, "~> 4.0"},
       {:argon2_elixir, "~> 1.2"},
 
+      # countries etc
+      {:excountries, "~> 0.0.1"},
+      {:yamerl, github: "yakaz/yamerl", override: true},
+      {:worldly, github: "martide/worldly"},
+      {:uuid, "~> 1.1"},
+
       # docs and tests
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8", only: :test},
       {:ex_machina, "~> 2.1", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:inch_ex, "~> 0.5.6", only: [:docs, :dev]},
-      {:excountries, "~> 0.0.1"},
-      {:yamerl, github: "yakaz/yamerl", override: true},
-      {:worldly, github: "martide/worldly"},
-      {:uuid, "~> 1.1"}
+      {:inch_ex, "~> 0.5.6", only: [:docs, :dev]}
+    ]
+  end
+
+  defp docs do
+    [
+      main: Core.Snitch.Data.Schema.Order,
+      source_url: "https://github.com/aviabird/snitch",
+      groups_for_modules: groups_for_modules()
+    ]
+  end
+
+  defp groups_for_modules do
+    [
+      Schema: ~r/^Core.Snitch.Data.Schema.?/,
+      Models: ~r/^Core.Snitch.Data.Model.?/,
+      Domain: ~r/^Core.Snitch.Domain.?/
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Snitch.Mixfile do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test, "coveralls.travis": :test, "coveralls.html": :test]
+      preferred_cli_env: [coveralls: :test, "coveralls.json": :test, "coveralls.html": :test]
     ]
   end
 


### PR DESCRIPTION
* [inch_ex](https://github.com/rrrene/inch_ex/blob/master/lib/inch_ex/reporter/remote.ex#L45) skips itself on PR builds, which means there's no need to build the project in `docs` env. In fact, Inch reports will now be made only if the commit is for `master` and `develop` branches.
* By sandwiching `mix format --check-formatted` by `set -e` and `set +e`, the build fails early. Otherwise, the tests ran even though the build was failing.
* CodeCov is much better than coveralls.