### PR TITLE
Set up zones for ShipmentMethod

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -66,7 +66,7 @@
         # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         #
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: [], mass_threshold: 41},
 
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just

--- a/.scripts/post-commit
+++ b/.scripts/post-commit
@@ -7,6 +7,6 @@ RED='\033[1;31m'
 LGRAY='\033[1;30m'
 NC='\033[0m' # No Color
 
-printf "${RED}Running 'mix credo --strict --format=oneline' on project...${NC}\n"
-mix credo --strict --format=oneline
+printf "${RED}Running 'mix credo --strict' on project...${NC}\n"
+mix credo --strict
 echo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ The repo includes some handy `git` hooks under `.scripts/`:
 
 We strongly recommend that you set up these git hooks on your machine by:
 ```sh
-ln -s .scripts/pre-commit .git/hooks/pre-commit
-ln -s .scripts/post-commit .git/hooks/post-commit
+# in the project root!
+ln -sf ../../.scripts/pre-commit .git/hooks/pre-commit
+ln -sf ../../.scripts/post-commit .git/hooks/post-commit
 ```
 
 > Note that our CI will fail your PR if you dont run `mix format` in the project

--- a/apps/snitch_core/lib/core/data/model/zone/country_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/country_zone.ex
@@ -1,0 +1,131 @@
+defmodule Snitch.Data.Model.CountryZone do
+  @moduledoc """
+  CountryZone API
+  """
+  use Snitch.Data.Model
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Snitch.Data.Schema.{CountryZoneMember, Zone, Country}
+
+  @doc """
+  Creates a new country `Zone` whose members are `country_ids`.
+
+  `country_ids` is a list of primary keys of the `Snitch.Data.Schema.Country`s that
+  make up this zone. Duplicate IDs are ignored.
+  """
+  @spec create(String.t(), String.t(), [non_neg_integer]) :: term
+  def create(name, description, country_ids) do
+    zone_params = %{name: name, description: description, zone_type: "C"}
+    zone_changeset = Zone.changeset(%Zone{}, zone_params, :create)
+
+    Multi.new()
+    |> Multi.insert(:zone, zone_changeset)
+    |> Multi.run(:members, fn %{zone: zone} -> insert_members(country_ids, zone) end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{zone: zone}} -> {:ok, zone}
+      error -> error
+    end
+  end
+
+  @spec delete(non_neg_integer | Zone.t()) ::
+          {:ok, Zone.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def delete(id_or_instance) do
+    QH.delete(Zone, id_or_instance, Repo)
+  end
+
+  @spec get(map | non_neg_integer) :: Zone.t() | nil
+  def get(query_fields_or_primary_key) do
+    QH.get(Zone, query_fields_or_primary_key, Repo)
+  end
+
+  @spec get_all() :: [Zone.t()]
+  def get_all, do: Repo.all(from(z in Zone, where: z.zone_type == "C"))
+
+  @doc """
+  Returns the list of `Country` IDs that make up this zone.
+  """
+  @spec member_ids(non_neg_integer) :: [non_neg_integer]
+  def member_ids(zone_id) do
+    query = from(m in CountryZoneMember, where: m.zone_id == ^zone_id, select: m.country_id)
+    Repo.all(query)
+  end
+
+  @doc """
+  Returns the list of `Country` structs that make up this zone.
+  """
+  @spec members(non_neg_integer) :: [Country.t()]
+  def members(zone_id) do
+    query =
+      from(
+        c in Country,
+        join: m in CountryZoneMember,
+        on: m.country_id == c.id,
+        where: m.zone_id == ^zone_id
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Updates Zone params and sets the members as per `new_country_ids`.
+
+  This replaces the old members with the new ones. Duplicate IDs in the list are
+  ignored.
+  """
+  @spec update(String.t(), String.t(), [non_neg_integer]) ::
+          {:ok, Zone.t()} | {:error, Ecto.Changeset.t()}
+  def update(zone, zone_params, new_country_ids) do
+    zone_changeset = Zone.changeset(zone, zone_params, :update)
+
+    old_members = MapSet.new(member_ids(zone.id))
+    new_members = MapSet.new(new_country_ids)
+    added = set_difference(new_members, old_members)
+    removed = set_difference(old_members, new_members)
+
+    delete_query =
+      from(m in CountryZoneMember, where: m.country_id in ^removed and m.zone_id == ^zone.id)
+
+    deletions_multi =
+      if length(removed) > 0 do
+        Multi.delete_all(%Multi{}, :removed, delete_query)
+      else
+        Multi.new()
+      end
+
+    Multi.new()
+    |> Multi.update(:zone, zone_changeset)
+    |> Multi.run(:added, fn _ -> insert_members(added, zone) end)
+    |> Multi.append(deletions_multi)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{zone: zone}} -> {:ok, zone}
+      error -> error
+    end
+  end
+
+  defp insert_members(country_ids, zone) do
+    country_ids
+    |> Stream.uniq()
+    |> Stream.map(
+      &CountryZoneMember.changeset(
+        %CountryZoneMember{},
+        %{country_id: &1, zone_id: zone.id},
+        :create
+      )
+    )
+    |> Stream.map(&Repo.insert/1)
+    |> Enum.reduce_while({:ok, []}, fn
+      {:ok, member}, {:ok, acc} -> {:cont, {:ok, [member | acc]}}
+      changeset, _acc -> {:halt, changeset}
+    end)
+  end
+
+  defp set_difference(a, b) do
+    a
+    |> MapSet.difference(b)
+    |> MapSet.to_list()
+  end
+end

--- a/apps/snitch_core/lib/core/data/model/zone/state_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/state_zone.ex
@@ -1,0 +1,131 @@
+defmodule Snitch.Data.Model.StateZone do
+  @moduledoc """
+  StateZone API
+  """
+  use Snitch.Data.Model
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Snitch.Data.Schema.{StateZoneMember, Zone, State}
+
+  @doc """
+  Creates a new state `Zone` whose members are `state_ids`.
+
+  `state_ids` is a list of primary keys of the `Snitch.Data.Schema.State`s that
+  make up this zone. Duplicate IDs are ignored.
+  """
+  @spec create(String.t(), String.t(), [non_neg_integer]) :: term
+  def create(name, description, state_ids) do
+    zone_params = %{name: name, description: description, zone_type: "S"}
+    zone_changeset = Zone.changeset(%Zone{}, zone_params, :create)
+
+    Multi.new()
+    |> Multi.insert(:zone, zone_changeset)
+    |> Multi.run(:members, fn %{zone: zone} -> insert_members(state_ids, zone) end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{zone: zone}} -> {:ok, zone}
+      error -> error
+    end
+  end
+
+  @spec delete(non_neg_integer | Zone.t()) ::
+          {:ok, Zone.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def delete(id_or_instance) do
+    QH.delete(Zone, id_or_instance, Repo)
+  end
+
+  @spec get(map | non_neg_integer) :: Zone.t() | nil
+  def get(query_fields_or_primary_key) do
+    QH.get(Zone, query_fields_or_primary_key, Repo)
+  end
+
+  @spec get_all() :: [Zone.t()]
+  def get_all, do: Repo.all(from(z in Zone, where: z.zone_type == "S"))
+
+  @doc """
+  Returns the list of `State` IDs that make up this zone.
+  """
+  @spec member_ids(non_neg_integer) :: [non_neg_integer]
+  def member_ids(zone_id) do
+    query = from(s in StateZoneMember, where: s.zone_id == ^zone_id, select: s.state_id)
+    Repo.all(query)
+  end
+
+  @doc """
+  Returns the list of `State` structs that make up this zone.
+  """
+  @spec members(non_neg_integer) :: [State.t()]
+  def members(zone_id) do
+    query =
+      from(
+        s in State,
+        join: m in StateZoneMember,
+        on: m.state_id == s.id,
+        where: m.zone_id == ^zone_id
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Updates Zone params and sets the members as per `new_state_ids`.
+
+  This replaces the old members with the new ones. Duplicate IDs in the list are
+  ignored.
+  """
+  @spec update(String.t(), String.t(), [non_neg_integer]) ::
+          {:ok, Zone.t()} | {:error, Ecto.Changeset.t()}
+  def update(zone, zone_params, new_state_ids) do
+    zone_changeset = Zone.changeset(zone, zone_params, :update)
+
+    old_members = MapSet.new(member_ids(zone.id))
+    new_members = MapSet.new(new_state_ids)
+    added = set_difference(new_members, old_members)
+    removed = set_difference(old_members, new_members)
+
+    delete_query =
+      from(m in StateZoneMember, where: m.state_id in ^removed and m.zone_id == ^zone.id)
+
+    deletions_multi =
+      if length(removed) > 0 do
+        Multi.delete_all(%Multi{}, :removed, delete_query)
+      else
+        Multi.new()
+      end
+
+    Multi.new()
+    |> Multi.update(:zone, zone_changeset)
+    |> Multi.run(:added, fn _ -> insert_members(added, zone) end)
+    |> Multi.append(deletions_multi)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{zone: zone}} -> {:ok, zone}
+      error -> error
+    end
+  end
+
+  defp insert_members(state_ids, zone) do
+    state_ids
+    |> Stream.uniq()
+    |> Stream.map(
+      &StateZoneMember.changeset(
+        %StateZoneMember{},
+        %{state_id: &1, zone_id: zone.id},
+        :create
+      )
+    )
+    |> Stream.map(&Repo.insert/1)
+    |> Enum.reduce_while({:ok, []}, fn
+      {:ok, member}, {:ok, acc} -> {:cont, {:ok, [member | acc]}}
+      changeset, _acc -> {:halt, changeset}
+    end)
+  end
+
+  defp set_difference(a, b) do
+    a
+    |> MapSet.difference(b)
+    |> MapSet.to_list()
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/zone/country_zone_member.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/country_zone_member.ex
@@ -1,0 +1,50 @@
+defmodule Snitch.Data.Schema.CountryZoneMember do
+  @moduledoc """
+  Models a CountryZone member.
+  """
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.{Zone, Country}
+
+  @typedoc """
+  CountryZoneMember struct.
+
+  ## Fields
+
+  * `zone_id` uniquely determines both `Zone` and `CountryZone`
+  """
+  @type t :: %__MODULE__{}
+
+  schema "snitch_country_zone_members" do
+    belongs_to(:zone, Zone)
+    belongs_to(:country, Country)
+    timestamps()
+  end
+
+  @update_fields ~w(country_id)a
+  @create_fields [:zone_id | @update_fields]
+
+  @doc """
+  Returns a `Zone` changeset.
+  """
+  @spec changeset(t, map, :create | :update) :: Ecto.Changeset.t()
+  def changeset(country_zone, params, :create) do
+    country_zone
+    |> cast(params, @create_fields)
+    |> validate_required(@create_fields)
+    |> foreign_key_constraint(:zone_id)
+    |> unique_constraint(:country_id, name: :snitch_country_zone_members_zone_id_country_id_index)
+    |> foreign_key_constraint(:country_id)
+    |> check_constraint(
+      :zone_id,
+      name: :country_zone_exclusivity,
+      message: "does not refer a country zone"
+    )
+  end
+
+  def changeset(country_zone, params, :update) do
+    country_zone
+    |> cast(params, @update_fields)
+    |> foreign_key_constraint(:country_id)
+    |> unique_constraint(:country_id, name: :snitch_country_zone_members_zone_id_country_id_index)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/zone/state_zone_member.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/state_zone_member.ex
@@ -1,0 +1,50 @@
+defmodule Snitch.Data.Schema.StateZoneMember do
+  @moduledoc """
+  Models a StateZone member.
+  """
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.{Zone, State}
+
+  @typedoc """
+  StateZoneMember struct.
+
+  ## Fields
+
+  * `zone_id` uniquely determines both `Zone` and `StateZone`
+  """
+  @type t :: %__MODULE__{}
+
+  schema "snitch_state_zone_members" do
+    belongs_to(:zone, Zone)
+    belongs_to(:state, State)
+    timestamps()
+  end
+
+  @update_fields ~w(state_id)a
+  @create_fields [:zone_id | @update_fields]
+
+  @doc """
+  Returns a `Zone` changeset.
+  """
+  @spec changeset(t, map, :create | :update) :: Ecto.Changeset.t()
+  def changeset(state_zone, params, :create) do
+    state_zone
+    |> cast(params, @create_fields)
+    |> validate_required(@create_fields)
+    |> foreign_key_constraint(:zone_id)
+    |> unique_constraint(:state_id, name: :snitch_state_zone_members_zone_id_state_id_index)
+    |> foreign_key_constraint(:state_id)
+    |> check_constraint(
+      :zone_id,
+      name: :state_zone_exclusivity,
+      message: "does not refer a state zone"
+    )
+  end
+
+  def changeset(state_zone, params, :update) do
+    state_zone
+    |> cast(params, @update_fields)
+    |> foreign_key_constraint(:state_id)
+    |> unique_constraint(:state_id, name: :snitch_state_zone_members_zone_id_state_id_index)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/zone.ex
@@ -1,0 +1,63 @@
+defmodule Snitch.Data.Schema.Zone do
+  @moduledoc """
+  Models a Zone.
+
+  `Zone` is a "supertype" ie, it is polymorphic. A zone may comprise of states
+  (`Snitch.Data.Schema.StateZone`), or countries
+  (`Snitch.Data.Schema.CountryZone`).
+  """
+
+  use Snitch.Data.Schema
+
+  @valid_zone_types ["S", "C"]
+  @readable_valid_zone_types @valid_zone_types
+                             |> Enum.map(fn x -> "`#{x}`" end)
+                             |> Enum.intersperse(", ")
+
+  @typedoc """
+  Zone struct.
+
+  ## Fields
+
+  * `zone_type` is a discriminator, the only valid values are the
+    characters [#{@readable_valid_zone_types}].
+  """
+  @type t :: %__MODULE__{}
+
+  schema "snitch_zones" do
+    field(:name, :string)
+    field(:description, :string)
+    field(:zone_type, :string)
+    timestamps()
+  end
+
+  @update_fields ~w(name description)a
+  @create_fields [:zone_type | @update_fields]
+
+  @doc """
+  Returns a `Zone` changeset.
+  """
+  @spec changeset(t, map, :create | :update) :: Ecto.Changeset.t()
+  def changeset(zone, params, :create) do
+    zone
+    |> cast(params, @create_fields)
+    |> validate_required(@create_fields)
+    |> validate_discriminator(:zone_type, @valid_zone_types)
+  end
+
+  def changeset(zone, params, :update) do
+    cast(zone, params, @update_fields)
+  end
+
+  defp validate_discriminator(%{valid?: false} = changeset, _, _), do: changeset
+
+  defp validate_discriminator(%{valid?: true} = changeset, key, permitted) do
+    {_, discriminator} = fetch_field(changeset, key)
+
+    if discriminator in permitted do
+      changeset
+    else
+      add_error(changeset, :zone_type, "'#{discriminator}' is invalid", validation: :inclusion)
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180307191719_create_zone_tables.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180307191719_create_zone_tables.exs
@@ -1,0 +1,49 @@
+defmodule Snitch.Repo.Migrations.CreateZoneTables do
+  use Ecto.Migration
+
+  @zone_exclusivity_fn ~s"""
+  create function zone_exclusivity(
+    in supertype_id bigint,
+    in subtype_discriminator varchar(1)
+    )
+  returns integer
+  as $$
+    select coalesce(
+      (select 1
+        from  snitch_zones
+        where id = supertype_id
+        and   zone_type = subtype_discriminator),
+      0)
+  $$                                   
+  language sql;
+  """
+
+  def change do
+    create table("snitch_zones") do
+      add :name, :string, null: :false
+      add :zone_type, :string, size: 1, null: false, comment: "discriminator"
+      add :description, :text, null: false
+      timestamps()
+    end
+    create constraint("snitch_zones", :valid_zone_type, check: "zone_type = any(array['S', 'C'])")
+
+    create table("snitch_state_zone_members") do
+      add :state_id, references("snitch_states", on_delete: :delete_all), null: false
+      add :zone_id, references("snitch_zones", on_delete: :delete_all), null: false
+      timestamps()
+    end
+    create unique_index("snitch_state_zone_members", [:zone_id, :state_id])
+
+    create table("snitch_country_zone_members") do
+      add :country_id, references("snitch_countries", on_delete: :delete_all), null: false
+      add :zone_id, references("snitch_zones", on_delete: :delete_all), null: false
+      timestamps()
+    end
+    create unique_index("snitch_country_zone_members", [:zone_id, :country_id])
+
+    execute @zone_exclusivity_fn, "drop function zone_exclusivity;"
+
+    create constraint("snitch_state_zone_members", :state_zone_exclusivity, check: "zone_exclusivity(zone_id, 'S') = 1")
+    create constraint("snitch_country_zone_members", :country_zone_exclusivity, check: "zone_exclusivity(zone_id, 'C') = 1")
+  end
+end

--- a/apps/snitch_core/test/data/model/stock/stock_item_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_item_test.exs
@@ -6,14 +6,14 @@ defmodule Snitch.Data.Model.StockItemTest do
 
   describe "create/4" do
     test "Fails for INVALID attributes" do
-      assert {:error, changeset} = Model.StockItem.create(1, 1, 1, true)
+      assert {:error, changeset} = Model.StockItem.create(-1, -1, 1, true)
       refute changeset.valid?
       assert %{stock_location_id: ["does not exist"]} = errors_on(changeset)
     end
 
     test "Fails with ONLY valid Stock Location" do
       stock_location = insert(:stock_location)
-      assert {:error, changeset} = Model.StockItem.create(1, stock_location.id, 1, true)
+      assert {:error, changeset} = Model.StockItem.create(-1, stock_location.id, 1, true)
       refute changeset.valid?
       assert %{variant_id: ["does not exist"]} = errors_on(changeset)
     end
@@ -36,7 +36,7 @@ defmodule Snitch.Data.Model.StockItemTest do
 
   describe "get/1" do
     test "Fails with invalid id" do
-      stock_item = Model.StockItem.get(1)
+      stock_item = Model.StockItem.get(-1)
       assert nil == stock_item
     end
 
@@ -94,7 +94,7 @@ defmodule Snitch.Data.Model.StockItemTest do
 
   describe "delete/1" do
     test "Fails to delete if invalid id" do
-      assert {:error, :not_found} = Model.StockItem.delete(1_234_567_890)
+      assert {:error, :not_found} = Model.StockItem.delete(-1)
     end
 
     test "Deletes for valid id" do
@@ -124,7 +124,7 @@ defmodule Snitch.Data.Model.StockItemTest do
 
   describe "with_active_stock_location/1" do
     test "returns empty list for invalid variant id" do
-      stock_items = Model.StockItem.with_active_stock_location(1_234_567_890)
+      stock_items = Model.StockItem.with_active_stock_location(-1)
       assert 0 = Enum.count(stock_items)
     end
 
@@ -149,7 +149,7 @@ defmodule Snitch.Data.Model.StockItemTest do
 
   describe "total_on_hand/1" do
     test "return nil for invalid variant id" do
-      assert nil == Model.StockItem.total_on_hand(1_234_567_890)
+      assert nil == Model.StockItem.total_on_hand(-1)
     end
 
     test "return total count on hand in all stock items for a variant at active locations" do
@@ -160,7 +160,7 @@ defmodule Snitch.Data.Model.StockItemTest do
 
       total_count_on_hand =
         stock_items
-        |> Enum.map(& &1.count_on_hand)
+        |> Stream.map(& &1.count_on_hand)
         |> Enum.reduce(0, &Kernel.+/2)
 
       assert total_count_on_hand == Model.StockItem.total_on_hand(variant.id)

--- a/apps/snitch_core/test/data/model/stock/stock_location_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_location_test.exs
@@ -18,14 +18,14 @@ defmodule Snitch.Data.Model.StockLocationTest do
 
     test "Fails for invalid associations" do
       assert {:error, changeset} =
-               Model.StockLocation.create("Digon Alley", "Street 10 London", 1, 1)
+               Model.StockLocation.create("Diagon Alley", "Street 10 London", -1, -1)
 
       assert %{state_id: ["does not exist"]} = errors_on(changeset)
 
       state = insert(:state)
 
       assert {:error, changeset} =
-               Model.StockLocation.create("Digon Alley", "Street 10 London", state.id, 1)
+               Model.StockLocation.create("Diagon Alley", "Street 10 London", state.id, -1)
 
       assert %{country_id: ["does not exist"]} = errors_on(changeset)
     end
@@ -33,7 +33,7 @@ defmodule Snitch.Data.Model.StockLocationTest do
     test "Inserts with valid attributes" do
       assert {:ok, _stock_location} =
                Model.StockLocation.create(
-                 "Digon Alley",
+                 "Diagon Alley",
                  "Street 10 London",
                  insert(:state).id,
                  insert(:country).id
@@ -43,7 +43,7 @@ defmodule Snitch.Data.Model.StockLocationTest do
 
   describe "get/1" do
     test "Fails with invalid id" do
-      stock_location = Model.StockLocation.get(1)
+      stock_location = Model.StockLocation.get(-1)
       assert nil == stock_location
     end
 
@@ -107,7 +107,7 @@ defmodule Snitch.Data.Model.StockLocationTest do
 
   describe "delete/1" do
     test "Fails to delete if invalid id" do
-      assert {:error, :not_found} = Model.StockLocation.delete(1_234_567_890)
+      assert {:error, :not_found} = Model.StockLocation.delete(-1)
     end
 
     test "Deletes for valid id" do

--- a/apps/snitch_core/test/data/model/zone/country_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/country_zone_test.exs
@@ -1,0 +1,85 @@
+defmodule Snitch.Data.Model.CountryZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Model.CountryZone
+  alias Snitch.Data.Schema.{Zone, CountryZoneMember}
+
+  setup :countries
+
+  @tag country_count: 3
+  describe "create/3 and member_ids" do
+    test "succeeds with valid country_ids", %{countries: countries} do
+      country_ids = Enum.map(countries, &Map.get(&1, :id))
+      duplicate_ids = country_ids ++ country_ids
+      assert {:ok, zone} = CountryZone.create("foo", "bar", duplicate_ids)
+
+      assert country_ids ==
+               Repo.all(
+                 from(c in CountryZoneMember, where: c.zone_id == ^zone.id, select: c.country_id)
+               )
+
+      assert country_ids == CountryZone.member_ids(zone.id)
+    end
+
+    test "fails if some states are invalid", %{countries: countries} do
+      country_ids = [-1 | Enum.map(countries, &Map.get(&1, :id))]
+      ordered_country_ids = Enum.reverse(country_ids)
+
+      assert {:error, :members, %{errors: errors}, %{zone: zone}} =
+               CountryZone.create("foo", "bar", ordered_country_ids)
+
+      assert nil == Repo.get(Zone, zone.id)
+      assert errors == [country_id: {"does not exist", []}]
+    end
+  end
+
+  @tag country_count: 3
+  describe "with country_zone" do
+    setup :country_zone
+
+    test "members/1 returns Country schemas", %{zone: zone, countries: countries} do
+      assert countries == CountryZone.members(zone.id)
+    end
+
+    test "delete/1 removes all members too", %{zone: zone} do
+      {:ok, _} = CountryZone.delete(zone)
+      assert [] = CountryZone.members(zone.id)
+    end
+
+    test "update/3 succeeds with valid country_ids", %{zone: zone, countries: countries} do
+      more_country_ids = Enum.map(insert_list(2, :country), &Map.get(&1, :id))
+      old_country_ids = Enum.map(countries, &Map.get(&1, :id))
+      new_country_ids = Enum.drop(old_country_ids, 1) ++ more_country_ids
+      assert {:ok, _} = CountryZone.update(zone, %{}, new_country_ids)
+      country_ids = MapSet.new(CountryZone.member_ids(zone.id))
+
+      assert new_country_ids
+             |> MapSet.new()
+             |> MapSet.equal?(country_ids)
+    end
+
+    test "update/3 succeeds with no states", %{zone: zone} do
+      assert {:ok, _} = CountryZone.update(zone, %{}, [])
+      assert [] = CountryZone.member_ids(zone.id)
+    end
+
+    test "update/3 fails with invalid states", %{zone: zone} do
+      old_country_ids = CountryZone.member_ids(zone.id)
+
+      assert {:error, :added, %{errors: errors}, %{zone: updated_zone}} =
+               CountryZone.update(zone, %{}, [-1])
+
+      assert errors == [country_id: {"does not exist", []}]
+      assert old_country_ids == CountryZone.member_ids(updated_zone.id)
+    end
+  end
+
+  defp country_zone(%{countries: countries}) do
+    country_ids = Enum.map(countries, &Map.get(&1, :id))
+    {:ok, zone} = CountryZone.create("foo", "bar", country_ids)
+    [zone: zone]
+  end
+end

--- a/apps/snitch_core/test/data/model/zone/state_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/state_zone_test.exs
@@ -1,0 +1,88 @@
+defmodule Snitch.Data.Model.StateZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Model.StateZone
+  alias Snitch.Data.Schema.{Zone, StateZoneMember}
+
+  setup :states
+
+  @tag state_count: 3
+  describe "create/3 and member_ids" do
+    test "succeeds with valid state_ids", %{states: states} do
+      state_ids = Enum.map(states, &Map.get(&1, :id))
+      duplicate_ids = state_ids ++ state_ids
+      assert {:ok, zone} = StateZone.create("foo", "bar", duplicate_ids)
+
+      assert state_ids ==
+               Repo.all(
+                 from(s in StateZoneMember, where: s.zone_id == ^zone.id, select: s.state_id)
+               )
+
+      assert state_ids == StateZone.member_ids(zone.id)
+    end
+
+    test "fails if some states are invalid", %{states: states} do
+      state_ids = [-1 | Enum.map(states, &Map.get(&1, :id))]
+      ordered_state_ids = Enum.reverse(state_ids)
+
+      assert {:error, :members, %{errors: errors}, %{zone: zone}} =
+               StateZone.create("foo", "bar", ordered_state_ids)
+
+      assert nil == Repo.get(Zone, zone.id)
+      assert errors == [state_id: {"does not exist", []}]
+    end
+  end
+
+  @tag state_count: 3
+  describe "with state_zone" do
+    setup :state_zone
+
+    test "members/1 returns State schemas", %{zone: zone, states: states} do
+      assert states ==
+               zone.id
+               |> StateZone.members()
+               |> Enum.map(&Repo.preload(&1, :country))
+    end
+
+    test "delete/1 removes all members too", %{zone: zone} do
+      {:ok, _} = StateZone.delete(zone)
+      assert [] = StateZone.members(zone.id)
+    end
+
+    test "update/3 succeeds with valid state_ids", %{zone: zone, states: states} do
+      more_state_ids = Enum.map(insert_list(2, :state), &Map.get(&1, :id))
+      old_state_ids = Enum.map(states, &Map.get(&1, :id))
+      new_state_ids = Enum.drop(old_state_ids, 1) ++ more_state_ids
+      assert {:ok, _} = StateZone.update(zone, %{}, new_state_ids)
+      state_ids = MapSet.new(StateZone.member_ids(zone.id))
+
+      assert new_state_ids
+             |> MapSet.new()
+             |> MapSet.equal?(state_ids)
+    end
+
+    test "update/3 succeeds with no states", %{zone: zone} do
+      assert {:ok, _} = StateZone.update(zone, %{}, [])
+      assert [] = StateZone.member_ids(zone.id)
+    end
+
+    test "update/3 fails with invalid states", %{zone: zone} do
+      old_state_ids = StateZone.member_ids(zone.id)
+
+      assert {:error, :added, %{errors: errors}, %{zone: updated_zone}} =
+               StateZone.update(zone, %{}, [-1])
+
+      assert errors == [state_id: {"does not exist", []}]
+      assert old_state_ids == StateZone.member_ids(updated_zone.id)
+    end
+  end
+
+  defp state_zone(%{states: states}) do
+    state_ids = Enum.map(states, &Map.get(&1, :id))
+    {:ok, zone} = StateZone.create("foo", "bar", state_ids)
+    [zone: zone]
+  end
+end

--- a/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
@@ -1,0 +1,39 @@
+defmodule Snitch.Data.Schema.CountryZoneMemberTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Schema.CountryZoneMember
+
+  setup :countries
+
+  describe "CountryZoneMember records" do
+    test "refer only country type zones", %{countries: [country]} do
+      country_zone = insert(:zone, zone_type: "C")
+
+      new_country_zone =
+        CountryZoneMember.changeset(
+          %CountryZoneMember{country_id: country.id},
+          %{zone_id: country_zone.id},
+          :create
+        )
+
+      assert {:ok, _} = Repo.insert(new_country_zone)
+    end
+
+    test "don't refer a state zone", %{countries: [country]} do
+      state_zone = insert(:zone, zone_type: "S")
+
+      new_country_zone =
+        CountryZoneMember.changeset(
+          %CountryZoneMember{country_id: country.id},
+          %{zone_id: state_zone.id},
+          :create
+        )
+
+      assert {:error, %Ecto.Changeset{errors: errors}} = Repo.insert(new_country_zone)
+      assert errors == [zone_id: {"does not refer a country zone", []}]
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
@@ -1,0 +1,39 @@
+defmodule Snitch.Data.Schema.StateZoneMemberTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Schema.StateZoneMember
+
+  setup :states
+
+  describe "StateZoneMember records" do
+    test "refer only state type zones", %{states: [state]} do
+      state_zone = insert(:zone, zone_type: "S")
+
+      new_state_zone =
+        StateZoneMember.changeset(
+          %StateZoneMember{state_id: state.id},
+          %{zone_id: state_zone.id},
+          :create
+        )
+
+      assert {:ok, _} = Repo.insert(new_state_zone)
+    end
+
+    test "don't refer a country zone", %{states: [state]} do
+      country_zone = insert(:zone, zone_type: "C")
+
+      new_state_zone =
+        StateZoneMember.changeset(
+          %StateZoneMember{state_id: state.id},
+          %{zone_id: country_zone.id},
+          :create
+        )
+
+      assert {:error, %Ecto.Changeset{errors: errors}} = Repo.insert(new_state_zone)
+      assert errors == [zone_id: {"does not refer a state zone", []}]
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/zone/zone_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/zone_test.exs
@@ -1,0 +1,14 @@
+defmodule Snitch.Data.Schema.ZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  alias Snitch.Data.Schema.Zone
+
+  test "Zone invalidates bad type" do
+    params = %{name: "foobar", description: "non-existent"}
+    zone = Zone.changeset(%Zone{zone_type: "x"}, params, :create)
+
+    assert %Ecto.Changeset{errors: errors} = zone
+    assert errors == [zone_type: {"'x' is invalid", [validation: :inclusion]}]
+  end
+end

--- a/apps/snitch_core/test/support/factory/address.ex
+++ b/apps/snitch_core/test/support/factory/address.ex
@@ -1,4 +1,4 @@
-defmodule Snitch.AddressFactory do
+defmodule Snitch.Factory.Address do
   @moduledoc false
 
   defmacro __using__(_opts) do
@@ -7,34 +7,44 @@ defmodule Snitch.AddressFactory do
 
       def state_factory do
         %State{
-          name: "London",
-          abbr: "LDN",
+          name: "California",
+          abbr: "CA",
           country: build(:country)
         }
       end
 
       def country_factory do
         %Country{
-          iso_name: "LDN",
-          iso: "+45",
-          iso3: "+45",
-          name: "United Kingdom",
-          numcode: "+45",
-          states_required: false
+          iso_name: sequence("UNITED STATES"),
+          iso: sequence("U"),
+          iso3: sequence("US"),
+          name: "United States",
+          numcode: "840",
+          states_required: true
         }
       end
 
       def address_factory do
         %Address{
-          first_name: sequence(:first_name, &"Diagon-#{&1}"),
-          last_name: sequence(:last_name, &"Alley-#{&1}"),
-          address_line_1: "Near",
-          address_line_2: "Gringotts",
-          city: "London",
-          zip_code: "123456",
-          phone: "987654321",
-          alternate_phone: "0987654321"
+          first_name: "Tony",
+          last_name: "Stark",
+          address_line_1: "10-8-80 Malibu Point",
+          zip_code: "90265",
+          city: "Malibu",
+          phone: "1234567890"
+          # state_id: State.get_id("California"),
+          # country_id: Country.get_id("USA"),
         }
+      end
+
+      def states(context) do
+        count = Map.get(context, :state_count, 1)
+        [states: insert_list(count, :state)]
+      end
+
+      def countries(context) do
+        count = Map.get(context, :country_count, 1)
+        [countries: insert_list(count, :country)]
       end
     end
   end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -2,7 +2,7 @@ defmodule Snitch.Factory do
   @moduledoc false
 
   use ExMachina.Ecto, repo: Snitch.Repo
-  use Snitch.{AddressFactory, StockFactory}
+  use Snitch.Factory.{Address, Stock, Zone}
 
   alias Snitch.Data.Schema.{Variant, Address, User, Order, Payment, PaymentMethod, CardPayment}
 

--- a/apps/snitch_core/test/support/factory/stock.ex
+++ b/apps/snitch_core/test/support/factory/stock.ex
@@ -1,4 +1,4 @@
-defmodule Snitch.StockFactory do
+defmodule Snitch.Factory.Stock do
   @moduledoc false
 
   defmacro __using__(_opts) do

--- a/apps/snitch_core/test/support/factory/zone.ex
+++ b/apps/snitch_core/test/support/factory/zone.ex
@@ -1,0 +1,16 @@
+defmodule Snitch.Factory.Zone do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Snitch.Data.Schema.{Zone, StateZone, CountryZone}
+
+      def zone_factory do
+        %Zone{
+          name: sequence("area", fn area_code -> "-#{area_code + 50}" end),
+          description: "Does area-51 exist?"
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
[**Pivotal Tracker story**](https://www.pivotaltracker.com/story/show/155785133)

### Schema
Zones are of two kinds (`State`, and `Country`), and this is another **non-exclusive** subtype-supertype relationship.

I've chosen to not keep schemas for `StateZone` and `CountryZone` subtype, as there's no table backing them. I considered making them `embedded_schema`s, but we can't put associations in them (can't do `state_zone_struct.members`).

### Models

Conversely, there's no model for `Zone`, instead we have models for `StateZone` and `CountryZone`.
`update/3` has a gotcha: there's no way to add/remove single members from the list.
  - This is because the UI element used to update the member list will definitely have the "new" member list.
  - `update` reduces the number of inserts and deletes to a minimum.

### Tasks

* [x] Speed up tests by using fixtures for state and country, not seed.