### PR TITLE
Improve user schema (issue #21)

### DIFF
--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -61,7 +61,7 @@ defmodule Snitch.Data.Schema.User do
 
   * `:create`
     - A map with fields first_name, last_name, email, password,
-      and password_confirmation are expected.
+      and password_confirmation is expected.
   * `:update`
     - No required fields.
 

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -50,30 +50,52 @@ defmodule Snitch.Data.Schema.User do
     timestamps()
   end
 
-  @required_fields ~w(first_name last_name email is_admin?)a
-  @password_fields ~w(password password_confirmation)a
+  @create_fields ~w(first_name last_name email is_admin?)a
+  @update_fields ~w(password password_confirmation)a
 
-  @spec registration_changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
+  # @spec registration_changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
   @doc """
   Returns a changeset to register a new user
   """
-  def registration_changeset(user, params) do
+  # def registration_changeset(user, params) do
+  #   user
+  #   |> changeset(params)
+  #   |> validate_required(@update_fields)
+  #   |> validate_confirmation(:password)
+  #   |> validate_password(:password)
+  #   |> put_pass_hash()
+  # end
+
+  # @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
+  # def changeset(user, params, action) do
+  #   user
+  #   |> cast(params, @create_fields ++ @update_fields)
+  #   |> validate_required(@update_fields)
+  #   |> validate_format(:email, ~r/@/)
+  #   |> unique_constraint(:email)
+  # end
+
+  @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
+  def changeset(user, params, action) do
     user
-    |> changeset(params)
-    |> validate_required(@password_fields)
+    |> cast(params, @create_fields ++ @update_fields)
     |> validate_confirmation(:password)
     |> validate_password(:password)
-    |> put_pass_hash()
+    |> validate_format(:email, ~r/@/)
+    |> do_changeset(action)
   end
 
-  @spec changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
-  def changeset(user, params) do
-    user
-    |> cast(params, @required_fields)
-    |> validate_required(@required_fields)
-    |> validate_format(:email, ~r/@/)
-    |> unique_constraint(:email)
+  defp create_changeset(user_changeset) do
+    user_changeset
+    |> validate_required(@create_fields ++ @update_fields)
   end
+
+  defp update_changeset(user_changeset) do
+    user_changeset
+  end
+
+  defp do_changeset(changeset, :create), do: create_changeset(changeset)
+  defp do_changeset(changeset, :update), do: update_changeset(changeset)
 
   defp validate_password(changeset, field) do
     validate_change(changeset, field, fn _, password ->
@@ -84,9 +106,13 @@ defmodule Snitch.Data.Schema.User do
     end)
   end
 
-  defp valid_password?(password) when byte_size(password) >= @password_min_length, do: :ok
+  defp valid_password?(password) when byte_size(password) >= @password_min_length do
+    IO.puts "PASSWORD VALID"
+    :ok
+  end
 
   defp valid_password?(_) do
+    IO.puts "PASSWORD INVALID"
     {:error, "The password must be #{@password_min_length} characters long."}
   end
 

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -17,7 +17,7 @@ defmodule Snitch.Data.Schema.User do
     field(:password, :string, virtual: true)
     field(:password_confirmation, :string, virtual: true)
     field(:password_hash, :string)
-    field(:is_admin?, :boolean, default: false)
+    field(:is_admin, :boolean, default: false)
 
     field(:sign_in_count, :integer, default: 0)
     field(:failed_attempts, :integer, default: 0)
@@ -50,12 +50,23 @@ defmodule Snitch.Data.Schema.User do
     timestamps()
   end
 
-  @create_fields ~w(first_name last_name email is_admin?)a
-  @update_fields ~w(password password_confirmation)a
+  @create_fields ~w(first_name last_name email password password_confirmation is_admin)a
+  @update_fields ~w(sign_in_count failed_attempts)a ++ @create_fields
 
-  # @spec registration_changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
+
   @doc """
-  Returns a changeset to register a new user
+  Returns a complete changeset with totals.
+
+  The `action` field can be either `:create` or `:update`.
+
+  * `:create`
+    - A map with fields first_name, last_name, email, password,
+      and password_confirmation are expected.
+  * `:update`
+    - No required fields.
+
+  ## Note
+  The changeset `action` is not set.
   """
 
   @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
@@ -71,7 +82,7 @@ defmodule Snitch.Data.Schema.User do
   @spec create_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp create_changeset(user_changeset) do
     user_changeset
-    |> validate_required(@create_fields ++ @update_fields)
+    |> validate_required(@create_fields)
     |> put_pass_hash
   end
 

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -57,23 +57,6 @@ defmodule Snitch.Data.Schema.User do
   @doc """
   Returns a changeset to register a new user
   """
-  # def registration_changeset(user, params) do
-  #   user
-  #   |> changeset(params)
-  #   |> validate_required(@update_fields)
-  #   |> validate_confirmation(:password)
-  #   |> validate_password(:password)
-  #   |> put_pass_hash()
-  # end
-
-  # @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
-  # def changeset(user, params, action) do
-  #   user
-  #   |> cast(params, @create_fields ++ @update_fields)
-  #   |> validate_required(@update_fields)
-  #   |> validate_format(:email, ~r/@/)
-  #   |> unique_constraint(:email)
-  # end
 
   @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
   def changeset(user, params, action) do
@@ -85,13 +68,17 @@ defmodule Snitch.Data.Schema.User do
     |> do_changeset(action)
   end
 
+  @spec create_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp create_changeset(user_changeset) do
     user_changeset
     |> validate_required(@create_fields ++ @update_fields)
+    |> put_pass_hash
   end
 
+  @spec update_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp update_changeset(user_changeset) do
     user_changeset
+    |> put_pass_hash
   end
 
   defp do_changeset(changeset, :create), do: create_changeset(changeset)
@@ -106,13 +93,9 @@ defmodule Snitch.Data.Schema.User do
     end)
   end
 
-  defp valid_password?(password) when byte_size(password) >= @password_min_length do
-    IO.puts "PASSWORD VALID"
-    :ok
-  end
+  defp valid_password?(password) when byte_size(password) >= @password_min_length, do: :ok
 
   defp valid_password?(_) do
-    IO.puts "PASSWORD INVALID"
     {:error, "The password must be #{@password_min_length} characters long."}
   end
 

--- a/apps/snitch_core/priv/repo/migrations/20180314173742_alter_user_password_hash_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314173742_alter_user_password_hash_field.exs
@@ -1,0 +1,9 @@
+defmodule Snitch.Repo.Migrations.AlterUserPasswordHashField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:snitch_users) do
+      modify(:password_hash, :string, null: false)
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180314181149_alter_user_timestamps.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314181149_alter_user_timestamps.exs
@@ -1,0 +1,10 @@
+defmodule Snitch.Repo.Migrations.AlterUserTimestamps do
+  use Ecto.Migration
+
+  def change do
+    alter table(:snitch_users) do
+      modify(:inserted_at, :naive_datetime, type: :utc_datetime)
+      modify(:updated_at, :naive_datetime, type: :utc_datetime)
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -14,14 +14,13 @@ defmodule Snitch.Data.Schema.UserTest do
     is_admin?: false
   }
 
-
-  test "new user changeset with valid attributes" do
-    %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :create)
-    assert validity
-  end
-
   describe "Create User" do
-    test "new user requires valid email" do
+    test "changeset with valid attributes" do
+      %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :create)
+      assert validity
+    end
+
+    test "requires valid email" do
       params = Map.delete(@valid_attrs, :email)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
       refute validity
@@ -33,15 +32,61 @@ defmodule Snitch.Data.Schema.UserTest do
       assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
     end
 
+    test "password hash" do
+      %{valid?: validity, changes: changes} = User.changeset(%User{}, @valid_attrs, :create)
+      assert validity
+      assert Map.has_key?(changes, :password_hash)
+      refute Map.has_key?(changes, :password)
+    end
+
+    test "password must have 8 characters" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "passwor" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert Keyword.get(errs, :password) == {"The password must be 8 characters long.", validation: :password}
+    end
+
+    test "password cannot be blank" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "" end)
+               |> Map.update!(:password_confirmation, fn _ -> "" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert Keyword.get(errs, :password) == {"can't be blank", validation: :required}
+    end
+
     test "password confirmation required" do
       params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
       %{valid?: validity, errors: [error | _]} = User.changeset(%User{}, params, :create)
       refute validity
-      assert error = {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
+      assert error == {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
     end
   end
 
   describe "Update User" do
+    test "changeset with valid attributes" do
+      %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :update)
+      assert validity
+    end
+
+    test "requires valid email" do
+      params = Map.delete(@valid_attrs, :email)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+      refute validity
+      assert Keyword.get(errs, :email) == {"can't be blank", [validation: :required]}
+
+      params = Map.update!(@valid_attrs, :email, fn _ -> "john_email.com" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+      refute validity
+      assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
+    end
+
+    test "password hash" do
+      %{valid?: validity, changes: changes} = User.changeset(%User{}, @valid_attrs, :update)
+      assert validity
+      assert Map.has_key?(changes, :password_hash)
+      refute Map.has_key?(changes, :password)
+    end
+
     test "password must have 8 characters" do
       params = Map.update!(@valid_attrs, :password, fn _ -> "passwor" end)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
@@ -50,18 +95,18 @@ defmodule Snitch.Data.Schema.UserTest do
     end
 
     test "password cannot be blank" do
-      params = Map.update!(@valid_attrs, :password, fn _ -> "1" end)
-               |> Map.update!(:password_confirmation, fn _ -> "1" end)
+      params = Map.update!(@valid_attrs, :password, fn _ -> "" end)
+               |> Map.update!(:password_confirmation, fn _ -> "" end)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
       refute validity
-      assert Keyword.get(errs, :password) == {"The password must be 8 characters long.", validation: :password}
+      assert Keyword.get(errs, :password) == {"can't be blank", validation: :required}
     end
 
     test "password confirmation required" do
       params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
-      %{valid?: validity, errors: [error | _]} = User.changeset(%User{}, params, :update)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
       refute validity
-      assert error = {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
+      assert Keyword.get(errs, :password_confirmation) == {"does not match confirmation", [validation: :confirmation]}
     end
   end
 

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -10,8 +10,7 @@ defmodule Snitch.Data.Schema.UserTest do
     last_name: "Doe",
     email: "john@domain.com",
     password: "password123",
-    password_confirmation: "password123",
-    is_admin?: false
+    password_confirmation: "password123"
   }
 
   describe "Create User" do
@@ -20,19 +19,21 @@ defmodule Snitch.Data.Schema.UserTest do
       assert validity
     end
 
-    test "requires valid email" do
+    test "email cannot be blank" do
       params = Map.delete(@valid_attrs, :email)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
       refute validity
       assert Keyword.get(errs, :email) == {"can't be blank", [validation: :required]}
+    end
 
+    test "email must be valid" do
       params = Map.update!(@valid_attrs, :email, fn _ -> "john_email.com" end)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
       refute validity
       assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
     end
 
-    test "password hash" do
+    test "password is stored as hash" do
       %{valid?: validity, changes: changes} = User.changeset(%User{}, @valid_attrs, :create)
       assert validity
       assert Map.has_key?(changes, :password_hash)
@@ -56,57 +57,65 @@ defmodule Snitch.Data.Schema.UserTest do
 
     test "password confirmation required" do
       params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
-      %{valid?: validity, errors: [error | _]} = User.changeset(%User{}, params, :create)
+      %{valid?: validity, errors: [error]} = User.changeset(%User{}, params, :create)
       refute validity
       assert error == {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
     end
+
+    test "first name and last name cannot be blank" do
+      params = Map.delete(@valid_attrs, :first_name)
+      %{valid?: validity, errors: [error]} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert error == {:first_name, {"can't be blank", [validation: :required]}}
+
+      params = Map.delete(@valid_attrs, :last_name)
+      %{valid?: validity, errors: [error]} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert error == {:last_name, {"can't be blank", [validation: :required]}}
+    end
+
+    # test "is_admin is not required" do
+    #   params = Map.delete(@valid_attrs, :is_admin)
+    #   IO.inspect params
+    #   %{valid?: validity} = User.changeset(%User{}, params, :create)
+    #   assert validity
+    # end
+
   end
 
   describe "Update User" do
-    test "changeset with valid attributes" do
-      %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :update)
-      assert validity
+    setup  do
+      cs = User.changeset(%User{}, @valid_attrs, :create)
+      [cs: cs]
     end
 
-    test "requires valid email" do
-      params = Map.delete(@valid_attrs, :email)
-      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
-      refute validity
-      assert Keyword.get(errs, :email) == {"can't be blank", [validation: :required]}
-
-      params = Map.update!(@valid_attrs, :email, fn _ -> "john_email.com" end)
-      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+    test "requires valid email", %{cs: changeset} do
+      params = %{email: "john_example.com"}
+      %{valid?: validity, errors: errs} = User.changeset(changeset, params, :update)
       refute validity
       assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
     end
 
-    test "password hash" do
-      %{valid?: validity, changes: changes} = User.changeset(%User{}, @valid_attrs, :update)
+    test "password is stored as hash", %{cs: changeset} do
+      params = %{password: "secret1234", password_confirmation: "secret1234"}
+      %{valid?: validity, changes: changes} = User.changeset(changeset, params, :update)
       assert validity
       assert Map.has_key?(changes, :password_hash)
       refute Map.has_key?(changes, :password)
     end
 
-    test "password must have 8 characters" do
-      params = Map.update!(@valid_attrs, :password, fn _ -> "passwor" end)
-      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+    test "password must have 8 characters", %{cs: changeset} do
+      params = %{password: "secret", password_confirmation: "secret"}
+      %{valid?: validity, errors: [err]} = User.changeset(changeset, params, :update)
       refute validity
-      assert Keyword.get(errs, :password) == {"The password must be 8 characters long.", validation: :password}
+      assert err == {:password, {"The password must be 8 characters long.", validation: :password}}
     end
 
-    test "password cannot be blank" do
-      params = Map.update!(@valid_attrs, :password, fn _ -> "" end)
-               |> Map.update!(:password_confirmation, fn _ -> "" end)
-      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+    test "password confirmation required", %{cs: changeset} do
+      params = %{password: "password1234", password_confirmation: "does not match"}
+      %{valid?: validity, errors: [err]} = User.changeset(changeset, params, :update)
       refute validity
-      assert Keyword.get(errs, :password) == {"can't be blank", validation: :required}
-    end
-
-    test "password confirmation required" do
-      params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
-      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
-      refute validity
-      assert Keyword.get(errs, :password_confirmation) == {"does not match confirmation", [validation: :confirmation]}
+      assert err == {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
     end
   end
 

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -1,0 +1,68 @@
+defmodule Snitch.Data.Schema.UserTest do
+  use ExUnit.Case
+  use Snitch.DataCase
+
+  alias Snitch.Data.Schema.User
+  alias Snitch.Data.Schema.Address
+
+  @valid_attrs %{
+    first_name: "John",
+    last_name: "Doe",
+    email: "john@domain.com",
+    password: "password123",
+    password_confirmation: "password123",
+    is_admin?: false
+  }
+
+
+  test "new user changeset with valid attributes" do
+    %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :create)
+    assert validity
+  end
+
+  describe "Create User" do
+    test "new user requires valid email" do
+      params = Map.delete(@valid_attrs, :email)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert Keyword.get(errs, :email) == {"can't be blank", [validation: :required]}
+
+      params = Map.update!(@valid_attrs, :email, fn _ -> "john_email.com" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
+    end
+
+    test "password confirmation required" do
+      params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
+      %{valid?: validity, errors: [error | _]} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert error = {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
+    end
+  end
+
+  describe "Update User" do
+    test "password must have 8 characters" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "passwor" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+      refute validity
+      assert Keyword.get(errs, :password) == {"The password must be 8 characters long.", validation: :password}
+    end
+
+    test "password cannot be blank" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "1" end)
+               |> Map.update!(:password_confirmation, fn _ -> "1" end)
+      %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :update)
+      refute validity
+      assert Keyword.get(errs, :password) == {"The password must be 8 characters long.", validation: :password}
+    end
+
+    test "password confirmation required" do
+      params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
+      %{valid?: validity, errors: [error | _]} = User.changeset(%User{}, params, :update)
+      refute validity
+      assert error = {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
+    end
+  end
+
+end

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -73,13 +73,6 @@ defmodule Snitch.Data.Schema.UserTest do
       assert error == {:last_name, {"can't be blank", [validation: :required]}}
     end
 
-    # test "is_admin is not required" do
-    #   params = Map.delete(@valid_attrs, :is_admin)
-    #   IO.inspect params
-    #   %{valid?: validity} = User.changeset(%User{}, params, :create)
-    #   assert validity
-    # end
-
   end
 
   describe "Update User" do

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -3,7 +3,6 @@ defmodule Snitch.Data.Schema.UserTest do
   use Snitch.DataCase
 
   alias Snitch.Data.Schema.User
-  alias Snitch.Data.Schema.Address
 
   @valid_attrs %{
     first_name: "John",
@@ -85,35 +84,37 @@ defmodule Snitch.Data.Schema.UserTest do
 
   describe "Update User" do
     setup  do
-      cs = User.changeset(%User{}, @valid_attrs, :create)
-      [cs: cs]
+      user = User.changeset(%User{}, @valid_attrs, :create)
+        |> Ecto.Changeset.apply_changes()
+
+      [user: user]
     end
 
-    test "requires valid email", %{cs: changeset} do
+    test "requires valid email", %{user: user} do
       params = %{email: "john_example.com"}
-      %{valid?: validity, errors: errs} = User.changeset(changeset, params, :update)
+      %{valid?: validity, errors: errs} = User.changeset(user, params, :update)
       refute validity
       assert Keyword.get(errs, :email) == {"has invalid format", [validation: :format]}
     end
 
-    test "password is stored as hash", %{cs: changeset} do
+    test "password is stored as hash", %{user: user} do
       params = %{password: "secret1234", password_confirmation: "secret1234"}
-      %{valid?: validity, changes: changes} = User.changeset(changeset, params, :update)
+      %{valid?: validity, changes: changes} = User.changeset(user, params, :update)
       assert validity
       assert Map.has_key?(changes, :password_hash)
       refute Map.has_key?(changes, :password)
     end
 
-    test "password must have 8 characters", %{cs: changeset} do
+    test "password must have 8 characters", %{user: user} do
       params = %{password: "secret", password_confirmation: "secret"}
-      %{valid?: validity, errors: [err]} = User.changeset(changeset, params, :update)
+      %{valid?: validity, errors: [err]} = User.changeset(user, params, :update)
       refute validity
       assert err == {:password, {"The password must be 8 characters long.", validation: :password}}
     end
 
-    test "password confirmation required", %{cs: changeset} do
+    test "password confirmation required", %{user: user} do
       params = %{password: "password1234", password_confirmation: "does not match"}
-      %{valid?: validity, errors: [err]} = User.changeset(changeset, params, :update)
+      %{valid?: validity, errors: [err]} = User.changeset(user, params, :update)
       refute validity
       assert err == {:password_confirmation, {"does not match confirmation", [validation: :confirmation]}}
     end

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -48,7 +48,6 @@ defmodule Snitch.Data.Schema.UserTest do
 
     test "password cannot be blank" do
       params = Map.update!(@valid_attrs, :password, fn _ -> "" end)
-               |> Map.update!(:password_confirmation, fn _ -> "" end)
       %{valid?: validity, errors: errs} = User.changeset(%User{}, params, :create)
       refute validity
       assert Keyword.get(errs, :password) == {"can't be blank", validation: :required}


### PR DESCRIPTION
Hello @oyeb.  Here are the changes I made.

1.  I refactored the changeset functions and I wrote tests for the user schema

2.  I made a migration to ensure the password_hash field is never null.  

3.  I wasn't clear as to which field you wanted to change to have type :utc_datetime.  However since the timestamps were the only field in the snitch_users table to have dates I assumed you meant those.  I made another migration to reflect that.  

I will continue working on the rest, but since we are on different time zones and @ashish173 expressed concern with speed let me know if you guys want to take over the rest from here.  
