### PR TITLE
User model and schema update

### DIFF
--- a/apps/snitch_core/lib/core/data/model/user.ex
+++ b/apps/snitch_core/lib/core/data/model/user.ex
@@ -1,0 +1,30 @@
+defmodule Snitch.Data.Model.User do
+  @moduledoc """
+  User API
+  """
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.User, as: UserSchema
+
+  @spec create(map) :: {:ok, UserSchema.t()} | {:error, Ecto.Changeset.t()}
+  def create(query_fields) do
+    QH.create(UserSchema, query_fields, Repo)
+  end
+
+  @spec update(map, UserSchema.t()) :: {:ok, UserSchema.t()} | {:error, Ecto.Changeset.t()}
+  def update(query_fields, instance) do
+    QH.update(UserSchema, query_fields, instance, Repo)
+  end
+
+  @spec delete(non_neg_integer | UserSchema.t()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  def delete(id_or_instance) do
+    QH.delete(UserSchema, id_or_instance, Repo)
+  end
+
+  @spec get(map | non_neg_integer) :: UserSchema.t() | nil
+  def get(query_fields_or_primary_key) do
+    QH.get(UserSchema, query_fields_or_primary_key, Repo)
+  end
+
+  @spec get_all() :: [UserSchema.t()]
+  def get_all(), do: Repo.all(UserSchema)
+end

--- a/apps/snitch_core/lib/core/data/model/user.ex
+++ b/apps/snitch_core/lib/core/data/model/user.ex
@@ -15,7 +15,8 @@ defmodule Snitch.Data.Model.User do
     QH.update(UserSchema, query_fields, instance, Repo)
   end
 
-  @spec delete(non_neg_integer | UserSchema.t()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  @spec delete(non_neg_integer | UserSchema.t()) ::
+          {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def delete(id_or_instance) do
     QH.delete(UserSchema, id_or_instance, Repo)
   end

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -89,7 +89,8 @@ defmodule Snitch.Data.Schema.User do
   defp update_changeset(%{changes: changes} = user_changeset) do
     cond do
       Map.has_key?(changes, :password) ->
-        user_changeset |> put_pass_hash
+        user_changeset
+        |> put_pass_hash
 
       true ->
         user_changeset

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -17,7 +17,7 @@ defmodule Snitch.Data.Schema.User do
     field(:password, :string, virtual: true)
     field(:password_confirmation, :string, virtual: true)
     field(:password_hash, :string)
-    field(:is_admin?, :boolean, default: false)
+    field(:is_admin, :boolean, default: false)
 
     field(:sign_in_count, :integer, default: 0)
     field(:failed_attempts, :integer, default: 0)
@@ -47,48 +47,57 @@ defmodule Snitch.Data.Schema.User do
     # field :deleted_at,             :naive_datetime
     # field :confirmed_at,           :naive_datetime
     # field :confirmation_sent_at,   :naive_datetime
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
-  @required_fields ~w(first_name last_name email is_admin?)a
-  @password_fields ~w(password password_confirmation)a
+  @create_fields ~w(first_name last_name email password password_confirmation is_admin)a
+  @update_fields ~w(sign_in_count failed_attempts)a ++ @create_fields
 
-  @spec registration_changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
+
   @doc """
-  Returns a changeset to register a new user
+  Returns a complete changeset depending on action.
+
+  The `action` field can be either `:create` or `:update`.
+
+  * `:create`
+    - A map with fields first_name, last_name, email, password,
+      and password_confirmation is expected.
+  * `:update`
+    - No required fields.
+
+  ## Note
+  The changeset `action` is not set.
   """
-  def registration_changeset(user, params) do
+
+  @spec changeset(__MODULE__.t(), map, :create | :update) :: Ecto.Changeset.t()
+  def changeset(user, params, action) do
     user
-    |> changeset(params)
-    |> validate_required(@password_fields)
+    |> cast(params, @create_fields ++ @update_fields)
     |> validate_confirmation(:password)
-    |> validate_password(:password)
-    |> put_pass_hash()
-  end
-
-  @spec changeset(__MODULE__.t(), map) :: Ecto.Changeset.t()
-  def changeset(user, params) do
-    user
-    |> cast(params, @required_fields)
-    |> validate_required(@required_fields)
+    |> validate_length(:password, min: @password_min_length)
     |> validate_format(:email, ~r/@/)
-    |> unique_constraint(:email)
+    |> do_changeset(action)
   end
 
-  defp validate_password(changeset, field) do
-    validate_change(changeset, field, fn _, password ->
-      case valid_password?(password) do
-        :ok -> []
-        {:error, msg} -> [{field, {msg, validation: :password}}]
-      end
-    end)
+  @spec create_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp create_changeset(user_changeset) do
+    user_changeset
+    |> validate_required(List.delete(@create_fields, :is_admin))
+    |> put_pass_hash
   end
 
-  defp valid_password?(password) when byte_size(password) >= @password_min_length, do: :ok
+  @spec update_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp update_changeset(%{changes: changes} = user_changeset) do
+    cond do
+      Map.has_key?(changes, :password) ->
+        user_changeset |> put_pass_hash
 
-  defp valid_password?(_) do
-    {:error, "The password must be #{@password_min_length} characters long."}
+      true -> user_changeset
+    end
   end
+
+  defp do_changeset(changeset, :create), do: create_changeset(changeset)
+  defp do_changeset(changeset, :update), do: update_changeset(changeset)
 
   defp put_pass_hash(%Ecto.Changeset{valid?: true} = changeset) do
     %Ecto.Changeset{changes: %{password: password}} = changeset

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -53,7 +53,6 @@ defmodule Snitch.Data.Schema.User do
   @create_fields ~w(first_name last_name email password password_confirmation is_admin)a
   @update_fields ~w(sign_in_count failed_attempts)a ++ @create_fields
 
-
   @doc """
   Returns a complete changeset depending on action.
 
@@ -92,7 +91,8 @@ defmodule Snitch.Data.Schema.User do
       Map.has_key?(changes, :password) ->
         user_changeset |> put_pass_hash
 
-      true -> user_changeset
+      true ->
+        user_changeset
     end
   end
 

--- a/apps/snitch_core/priv/repo/migrations/20180314173742_alter_user_password_hash_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314173742_alter_user_password_hash_field.exs
@@ -1,0 +1,15 @@
+defmodule Snitch.Repo.Migrations.AlterUserPasswordHashField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:snitch_users) do
+      modify(:password_hash, :string, null: false)
+    end
+  end
+
+  def down do
+    alter table(:snitch_users) do
+      modify(:password_hash, :string)
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180314181149_alter_user_timestamps.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314181149_alter_user_timestamps.exs
@@ -1,0 +1,17 @@
+defmodule Snitch.Repo.Migrations.AlterUserTimestamps do
+  use Ecto.Migration
+
+  def change do
+    alter table(:snitch_users) do
+      modify(:inserted_at, :naive_datetime, type: :utc_datetime)
+      modify(:updated_at, :naive_datetime, type: :utc_datetime)
+    end
+  end
+
+  def down do
+    alter table(:snitch_users) do
+      modify(:inserted_at, :utc_datetime, type: :naive_datetime)
+      modify(:updated_at, :utc_datetime, type: :naive_datetime)
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180314224913_rename_users_is_admin_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314224913_rename_users_is_admin_field.exs
@@ -1,0 +1,11 @@
+defmodule Snitch.Repo.Migrations.RenameUsersIsAdminField do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:snitch_users), :is_admin?, to: :is_admin)
+  end
+
+  def down do
+    rename(table(:snitch_users), :is_admin, to: :is_admin?)
+  end
+end

--- a/apps/snitch_core/test/data/model/user_test.exs
+++ b/apps/snitch_core/test/data/model/user_test.exs
@@ -2,7 +2,6 @@ defmodule Snitch.Data.Model.UserTest do
   use ExUnit.Case, async: true
   use Snitch.DataCase
 
-
   alias Snitch.Data.Model.User
   alias Snitch.Data.Schema.User, as: UserSchema
 
@@ -14,11 +13,11 @@ defmodule Snitch.Data.Model.UserTest do
       password: "password123",
       password_confirmation: "password123"
     }
+
     [valid_attrs: valid_attrs]
   end
 
   describe "create/1" do
-
     test "inserts with valid attributes", %{valid_attrs: va} do
       assert {:ok, %UserSchema{}} = User.create(va)
     end
@@ -66,6 +65,5 @@ defmodule Snitch.Data.Model.UserTest do
       assert {:ok, %{id: received_id} = %UserSchema{}} = User.delete(uid)
       assert received_id == uid
     end
-
   end
 end

--- a/apps/snitch_core/test/data/model/user_test.exs
+++ b/apps/snitch_core/test/data/model/user_test.exs
@@ -1,0 +1,71 @@
+defmodule Snitch.Data.Model.UserTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+
+  alias Snitch.Data.Model.User
+  alias Snitch.Data.Schema.User, as: UserSchema
+
+  setup do
+    valid_attrs = %{
+      first_name: "John",
+      last_name: "Doe",
+      email: "john@domain.com",
+      password: "password123",
+      password_confirmation: "password123"
+    }
+    [valid_attrs: valid_attrs]
+  end
+
+  describe "create/1" do
+
+    test "inserts with valid attributes", %{valid_attrs: va} do
+      assert {:ok, %UserSchema{}} = User.create(va)
+    end
+
+    test "FAILS for invalid attributes", %{valid_attrs: va} do
+      params = Map.update!(va, :password_confirmation, fn _ -> "does not match" end)
+      assert {:error, changeset} = User.create(params)
+      refute changeset.valid?
+      assert %{password_confirmation: ["does not match confirmation"]} = errors_on(changeset)
+    end
+  end
+
+  describe "update/2" do
+    setup %{valid_attrs: va} do
+      {:ok, user} = User.create(va)
+      [user: user]
+    end
+
+    test "inserts with valid attributes", %{user: user} do
+      %{id: expected_id} = user
+      updates = %{first_name: "jordan"}
+      assert {:ok, %{id: received_id}} = User.update(updates, user)
+      assert expected_id == received_id
+    end
+
+    test "FAILS for invalid attributes", %{user: user} do
+      updates = %{email: "john_example.com"}
+      {:error, changeset} = User.update(updates, user)
+      refute changeset.valid?
+      assert %{email: ["has invalid format"]} = errors_on(changeset)
+    end
+  end
+
+  describe "delete/2" do
+    setup %{valid_attrs: va} do
+      {:ok, %{id: user_id}} = User.create(va)
+      [user_id: user_id]
+    end
+
+    test "FAILS to delete for invalid id" do
+      assert {:error, :not_found} = User.delete(-1)
+    end
+
+    test "deletes for valid id", %{user_id: uid} do
+      assert {:ok, %{id: received_id} = %UserSchema{}} = User.delete(uid)
+      assert received_id == uid
+    end
+
+  end
+end

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -1,0 +1,121 @@
+defmodule Snitch.Data.Schema.UserTest do
+  use ExUnit.Case
+  use Snitch.DataCase
+
+  alias Snitch.Data.Schema.User
+
+  @valid_attrs %{
+    first_name: "John",
+    last_name: "Doe",
+    email: "john@domain.com",
+    password: "password123",
+    password_confirmation: "password123"
+  }
+
+  describe "Create User" do
+    test "changeset with valid attributes" do
+      %{valid?: validity} = User.changeset(%User{}, @valid_attrs, :create)
+      assert validity
+    end
+
+    test "email cannot be blank" do
+      params = Map.delete(@valid_attrs, :email)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{email: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "email must be valid" do
+      params = Map.update!(@valid_attrs, :email, fn _ -> "john_email.com" end)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{email: ["has invalid format"]} = errors_on(cs)
+    end
+
+    test "password is stored as hash" do
+      %{valid?: validity, changes: changes} = User.changeset(%User{}, @valid_attrs, :create)
+      assert validity
+      assert Map.has_key?(changes, :password_hash)
+      refute Map.has_key?(changes, :password)
+    end
+
+    test "password must have 8 characters" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "passwor" end)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{password: ["should be at least 8 character(s)"]} = errors_on(cs)
+    end
+
+    test "password cannot be blank" do
+      params = Map.update!(@valid_attrs, :password, fn _ -> "" end)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{password: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "password confirmation required" do
+      params = Map.update!(@valid_attrs, :password_confirmation, fn _ -> "password" end)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{password_confirmation: ["does not match confirmation"]} = errors_on(cs)
+    end
+
+    test "first name and last name cannot be blank" do
+      params = Map.delete(@valid_attrs, :first_name)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{first_name: ["can't be blank"]} = errors_on(cs)
+
+      params = Map.delete(@valid_attrs, :last_name)
+      cs = %{valid?: validity} = User.changeset(%User{}, params, :create)
+      refute validity
+      assert %{last_name: ["can't be blank"]} = errors_on(cs)
+    end
+
+  end
+
+  describe "Update User" do
+    setup  do
+      user = User.changeset(%User{}, @valid_attrs, :create)
+        |> Ecto.Changeset.apply_changes()
+
+      [user: user]
+    end
+
+    test "valid attributes", %{user: user} do
+      params = %{email: "john@example.com"}
+      %{valid?: validity} = User.changeset(user, params, :update)
+      assert validity
+    end
+
+    test "requires valid email", %{user: user} do
+      params = %{email: "john_example.com"}
+      cs = %{valid?: validity} = User.changeset(user, params, :update)
+      refute validity
+      assert %{email: ["has invalid format"]} = errors_on(cs)
+    end
+
+    test "password is stored as hash", %{user: user} do
+      params = %{password: "secret1234", password_confirmation: "secret1234"}
+      %{valid?: validity, changes: changes} = User.changeset(user, params, :update)
+      assert validity
+      assert Map.has_key?(changes, :password_hash)
+      refute Map.has_key?(changes, :password)
+    end
+
+    test "password must have 8 characters", %{user: user} do
+      params = %{password: "secret", password_confirmation: "secret"}
+      cs = %{valid?: validity} = User.changeset(user, params, :update)
+      refute validity
+      assert %{password: ["should be at least 8 character(s)"]} = errors_on(cs)
+    end
+
+    test "password confirmation required", %{user: user} do
+      params = %{password: "password1234", password_confirmation: "does not match"}
+      cs = %{valid?: validity} = User.changeset(user, params, :update)
+      refute validity
+      assert %{password_confirmation: ["does not match confirmation"]} = errors_on(cs)
+    end
+  end
+
+end

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -71,12 +71,12 @@ defmodule Snitch.Data.Schema.UserTest do
       refute validity
       assert %{last_name: ["can't be blank"]} = errors_on(cs)
     end
-
   end
 
   describe "Update User" do
-    setup  do
-      user = User.changeset(%User{}, @valid_attrs, :create)
+    setup do
+      user =
+        User.changeset(%User{}, @valid_attrs, :create)
         |> Ecto.Changeset.apply_changes()
 
       [user: user]
@@ -117,5 +117,4 @@ defmodule Snitch.Data.Schema.UserTest do
       assert %{password_confirmation: ["does not match confirmation"]} = errors_on(cs)
     end
   end
-
 end


### PR DESCRIPTION
Hello @oyeb. Here are the changes I made.

  1.  I refactored the changeset functions and I wrote tests for the user schema

  2. I made a migration to ensure the password_hash field is never null.

  3. I wasn't clear as to which field you wanted to change to have type :utc_datetime. However since the       timestamps were the only field in the snitch_users table to have dates I assumed you meant those. I made another migration to reflect that.

  4.  I made a migration that renamed the is_admin? field in the snitch_users table to is_admin

  5. I created the user model with tests. 

  6. I found an issue in QueryHelper.  In the private function commit_if_valid it was returning the following on error, {:error, changeset.errors}, which violates the return value spec of                          {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}.  I had to make this change for my tests in Model.User to pass.  


I assumed, since you moved the address association to another issue, that you would want the improvements to user_with_address in factory.ex taken care of in that issue as well.  
