### PR TITLE
Add pwd_hash to user factory and fix query_helper

### DIFF
--- a/apps/snitch_core/lib/core/tools/helpers/query_helper/query_helper.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/query_helper/query_helper.ex
@@ -60,7 +60,7 @@ defmodule Snitch.Tools.QueryHelper do
         :update -> repo.update(changeset)
       end
     else
-      {:error, changeset.errors}
+      {:error, changeset}
     end
   end
 end

--- a/apps/snitch_core/test/data/model/payment/payment_method_test.exs
+++ b/apps/snitch_core/test/data/model/payment/payment_method_test.exs
@@ -17,9 +17,8 @@ defmodule Snitch.Data.Model.PaymentMethodTest do
   end
 
   test "create with bad code fails" do
-    assert {:error,
-            [code: {"should be %{count} character(s)", [count: 3, validation: :length, is: 3]}]} =
-             Model.PaymentMethod.create("card-payments", "not-a-code")
+    assert {:error, changeset} = Model.PaymentMethod.create("card-payments", "not-a-code")
+    assert %{code: ["should be 3 character(s)"]} = errors_on(changeset)
   end
 
   describe "with existing" do

--- a/apps/snitch_core/test/data/model/stock/stock_item_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_item_test.exs
@@ -23,20 +23,14 @@ defmodule Snitch.Data.Model.StockItemTest do
       variant = insert(:variant)
 
       assert {:error, changeset} = Model.StockItem.create(variant.id, stock_location.id, -1, true)
-
-      assert [
-               count_on_hand: {
-                 "must be greater than %{number}",
-                 [validation: :number, number: -1]
-               }
-             ] = changeset
+      assert %{count_on_hand: ["must be greater than -1"]} = errors_on(changeset)
     end
 
     test "Inserts with valid attributes" do
       stock_location = insert(:stock_location)
       variant = insert(:variant)
 
-      assert {:ok, stock_item} = Model.StockItem.create(variant.id, stock_location.id, 1, true)
+      assert {:ok, _stock_item} = Model.StockItem.create(variant.id, stock_location.id, 1, true)
     end
   end
 
@@ -69,13 +63,7 @@ defmodule Snitch.Data.Model.StockItemTest do
       stock_item = insert(:stock_item)
 
       assert {:error, changeset} = Model.StockItem.update(%{count_on_hand: -1, id: stock_item.id})
-
-      assert [
-               count_on_hand: {
-                 "must be greater than %{number}",
-                 [validation: :number, number: -1]
-               }
-             ] = changeset
+      assert %{count_on_hand: ["must be greater than -1"]} = errors_on(changeset)
     end
 
     test "without stock instance : updates for VALID attributes" do
@@ -91,13 +79,7 @@ defmodule Snitch.Data.Model.StockItemTest do
     test "with stock instance : Fails for INVALID attributes" do
       stock_item = insert(:stock_item)
       assert {:error, changeset} = Model.StockItem.update(%{count_on_hand: -1}, stock_item)
-
-      assert [
-               count_on_hand: {
-                 "must be greater than %{number}",
-                 [validation: :number, number: -1]
-               }
-             ] = changeset
+      assert %{count_on_hand: ["must be greater than -1"]} = errors_on(changeset)
     end
 
     test "with stock instance : updates for VALID attributes" do
@@ -117,12 +99,12 @@ defmodule Snitch.Data.Model.StockItemTest do
 
     test "Deletes for valid id" do
       stock_item = insert(:stock_item)
-      assert stock_item = Model.StockItem.delete(stock_item.id)
+      assert {:ok, _} = Model.StockItem.delete(stock_item.id)
     end
 
     test "Deletes for valid stock item" do
       stock_item = insert(:stock_item)
-      assert stock_item = Model.StockItem.delete(stock_item)
+      assert {:ok, _} = Model.StockItem.delete(stock_item)
     end
   end
 

--- a/apps/snitch_core/test/data/model/stock/stock_location_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_location_test.exs
@@ -8,12 +8,12 @@ defmodule Snitch.Data.Model.StockLocationTest do
     test "Fails for blank attributes" do
       assert {:error, changeset} = Model.StockLocation.create("", "", nil, nil)
 
-      assert [
-               name: {"can't be blank", [validation: :required]},
-               address_line_1: {"can't be blank", [validation: :required]},
-               state_id: {"can't be blank", [validation: :required]},
-               country_id: {"can't be blank", [validation: :required]}
-             ] = changeset
+      assert %{
+               address_line_1: ["can't be blank"],
+               country_id: ["can't be blank"],
+               name: ["can't be blank"],
+               state_id: ["can't be blank"]
+             } = errors_on(changeset)
     end
 
     test "Fails for invalid associations" do
@@ -31,7 +31,7 @@ defmodule Snitch.Data.Model.StockLocationTest do
     end
 
     test "Inserts with valid attributes" do
-      assert {:ok, stock_location} =
+      assert {:ok, _stock_location} =
                Model.StockLocation.create(
                  "Digon Alley",
                  "Street 10 London",
@@ -57,7 +57,6 @@ defmodule Snitch.Data.Model.StockLocationTest do
       # with stock location map
       get_stock_location_with_map = Model.StockLocation.get(%{id: insert_stock_location.id})
       assert insert_stock_location.id == get_stock_location_with_map.id
-      assert insert_stock_location.id == get_stock_location_with_map.id
       assert insert_stock_location.name == get_stock_location_with_map.name
     end
   end
@@ -69,10 +68,10 @@ defmodule Snitch.Data.Model.StockLocationTest do
       assert {:error, changeset} =
                Model.StockLocation.update(%{name: "", address_line_1: "", id: stock_location.id})
 
-      assert [
-               name: {"can't be blank", [validation: :required]},
-               address_line_1: {"can't be blank", [validation: :required]}
-             ] = changeset
+      assert %{
+               name: ["can't be blank"],
+               address_line_1: ["can't be blank"]
+             } = errors_on(changeset)
     end
 
     test "without instance object params : updates for VALID attributes" do
@@ -90,10 +89,10 @@ defmodule Snitch.Data.Model.StockLocationTest do
       assert {:error, changeset} =
                Model.StockLocation.update(%{name: "", address_line_1: ""}, stock_location)
 
-      assert [
-               name: {"can't be blank", [validation: :required]},
-               address_line_1: {"can't be blank", [validation: :required]}
-             ] = changeset
+      assert %{
+               name: ["can't be blank"],
+               address_line_1: ["can't be blank"]
+             } = errors_on(changeset)
     end
 
     test "with instance object params : updates for VALID attributes" do
@@ -113,12 +112,12 @@ defmodule Snitch.Data.Model.StockLocationTest do
 
     test "Deletes for valid id" do
       stock_location = insert(:stock_location)
-      assert stock_location = Model.StockLocation.delete(stock_location.id)
+      assert {:ok, _} = Model.StockLocation.delete(stock_location.id)
     end
 
     test "Deletes for valid stock location" do
       stock_location = insert(:stock_location)
-      assert stock_location = Model.StockLocation.delete(stock_location)
+      assert {:ok, _} = Model.StockLocation.delete(stock_location)
     end
   end
 

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -10,11 +10,12 @@ defmodule Snitch.Factory do
     %User{
       first_name: sequence(:first_name, &"Tony-#{&1}"),
       last_name: sequence(:last_name, &"Stark-#{&1}"),
-      email: sequence(:email, &"ceo-#{&1}@stark.com")
+      email: sequence(:email, &"ceo-#{&1}@stark.com"),
+      password_hash: "NOTASECRET"
     }
   end
 
-  def random_variant_factory() do
+  def random_variant_factory do
     %Variant{
       sku: sequence(:sku, &"shoes-nike-#{&1}"),
       weight: Decimal.new("0.45"),


### PR DESCRIPTION
* `QueryHelper` should return the complete changeset in case of errors, not just the errors list.
* Updated tests to use `Snitch.DataCase.errors_on` to traverse the changeset errors.