### PR TITLE
Setup ShippingMethod CRUD

### DIFF
--- a/apps/snitch_core/lib/core/data/model/shipping_method.ex
+++ b/apps/snitch_core/lib/core/data/model/shipping_method.ex
@@ -1,0 +1,61 @@
+defmodule Snitch.Data.Model.ShippingMethod do
+  @moduledoc """
+  ShippingMethod API
+  """
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.ShippingMethod, as: SMSchema
+  alias Snitch.Data.Schema.Zone
+
+  @doc """
+  Creates a ShippingMethod with given Zones.
+
+  The `zones` must be `Snitch.Data.Schema.Zone.t` structs.
+  """
+  @spec create(map, [Zone.t()]) :: {:ok, SMSchema.t()} | {:error, Ecto.Changeset.t()}
+  def create(params, zone_structs) do
+    cs = SMSchema.changeset(%SMSchema{}, params, zone_structs, :create)
+    Repo.insert(cs)
+  end
+
+  @doc """
+  Updates a ShippingMethod.
+
+  The `zones` must be `Snitch.Data.Schema.Zone.t` structs. These `zones` are set
+  as the zones in this `shipping_method` and effectively replace the previous
+  ones.
+
+  ## Updating the zones
+  ```
+  new_params = %{name: "hyperloop"}
+  new_zones = Repo.all(from z in Schema.Zone, where: like(z.name, "spacex%"))
+  {:ok, sm} = Model.ShippingMethod.update(shipping_method, new_params, new_zones)
+  ```
+
+  ## Updating only params (not zones)
+  ```
+  new_params = %{name: "hyperloop"}
+  sm_preloaded = Repo.preload(shipping_method, :zones)
+  {:ok, sm} = Model.ShippingMethod.update(sm_preloaded, new_params, sm_preloaded.zones)
+  ```
+  """
+  @spec update(SMSchema.t(), map, [Zone.t()]) ::
+          {:ok, SMSchema.t()} | {:error, Ecto.Changeset.t()}
+  def update(shipping_method, params, zone_structs) do
+    cs = SMSchema.changeset(shipping_method, params, zone_structs, :update)
+    Repo.update(cs)
+  end
+
+  @spec delete(non_neg_integer | SMSchema.t()) ::
+          {:ok, SMSchema.t()} | {:error, Ecto.Changeset.t()}
+  def delete(id_or_instance) do
+    QH.delete(SMSchema, id_or_instance, Repo)
+  end
+
+  @spec get(map | non_neg_integer) :: SMSchema.t() | nil
+  def get(query_fields_or_primary_key) do
+    QH.get(SMSchema, query_fields_or_primary_key, Repo)
+  end
+
+  @spec get_all :: [SMSchema.t()]
+  def get_all, do: Repo.all(SMSchema)
+end

--- a/apps/snitch_core/lib/core/data/schema/shipping_method.ex
+++ b/apps/snitch_core/lib/core/data/schema/shipping_method.ex
@@ -7,7 +7,6 @@ defmodule Snitch.Data.Schema.ShippingMethod do
     > A particular Zone may have none or many ShippingMethods -- a classic
       many-to-many relation.
   * can have both Country and State Zones.
-
   """
 
   use Snitch.Data.Schema

--- a/apps/snitch_core/lib/core/data/schema/shipping_method.ex
+++ b/apps/snitch_core/lib/core/data/schema/shipping_method.ex
@@ -1,0 +1,68 @@
+defmodule Snitch.Data.Schema.ShippingMethod do
+  @moduledoc """
+  Models a ShippingMethod that caters to a set of Zones and ShippingCategories.
+
+  A ShippingMethod,
+  * may belong to zero or more unique zones.
+    > A particular Zone may have none or many ShippingMethods -- a classic
+      many-to-many relation.
+  * can have both Country and State Zones.
+
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.{Zone}
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_shipping_methods" do
+    field(:slug, :string)
+    field(:name, :string)
+    field(:description, :string)
+
+    many_to_many(
+      :zones,
+      Zone,
+      join_through: "snitch_shipping_methods_zones",
+      unique: true,
+      on_replace: :delete
+    )
+
+    # many_to_many :zones, ShippingCategory, join_through: "snitch_shipping_methods_categories"
+    timestamps()
+  end
+
+  @create_fields ~w(slug name description)a
+  @required_fields @create_fields
+
+  @doc """
+  Returns a ShippingMethod changeset depending on `action`
+
+  If the `action` is `:create`, `[#{
+    @required_fields
+    |> Enum.map(fn x -> ":#{x}" end)
+    |> Enum.intersperse(", ")
+  }]`
+  are required.
+
+  The `zones` must be `Snitch.Data.Schema.Zone.t` structs. Even if `action` is
+  `:update` a full list of the desired zone structs is expected.
+  """
+  @spec changeset(t, %{}, [Zone], :create | :update) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = shipping_method, params, zones, :create) do
+    shipping_method
+    |> common_changeset(params, zones)
+    |> validate_required(@required_fields)
+  end
+
+  def changeset(%__MODULE__{} = shipping_method, params, zones, :update) do
+    common_changeset(shipping_method, params, zones)
+  end
+
+  defp common_changeset(%__MODULE__{} = shipping_method, params, zones) do
+    shipping_method
+    |> cast(params, @create_fields)
+    |> unique_constraint(:slug)
+    |> put_assoc(:zones, zones)
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180314175021_create_shipping_method_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180314175021_create_shipping_method_table.exs
@@ -1,0 +1,18 @@
+defmodule Snitch.Repo.Migrations.CreateShippingMethodTable do
+  use Ecto.Migration
+
+  def change do
+    create table("snitch_shipping_methods") do
+      add :slug, :string, null: :false
+      add :name, :string, null: :false
+      add :description, :text, null: false
+      timestamps()
+    end
+    create unique_index("snitch_shipping_methods", :slug)
+
+    create table("snitch_shipping_methods_zones") do
+      add :shipping_method_id, references("snitch_shipping_methods", on_delete: :delete_all)
+      add :zone_id, references("snitch_zones", on_delete: :delete_all)
+    end
+  end
+end

--- a/apps/snitch_core/test/data/model/shipping_method_test.exs
+++ b/apps/snitch_core/test/data/model/shipping_method_test.exs
@@ -1,0 +1,55 @@
+defmodule Snitch.Data.Model.ShippingMethodTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Model.ShippingMethod
+
+  @valid_params %{
+    slug: "shipping_method",
+    name: "hyperloop",
+    description: "Brought to you by spacex!"
+  }
+
+  setup :zones
+
+  describe "create" do
+    @tag state_zone_count: 1, country_zone_count: 1
+    test "with valid params and zones", %{zones: zones} do
+      {:ok, sm} = ShippingMethod.create(@valid_params, zones)
+      assert Enum.count(sm.zones) == 2
+    end
+
+    test "with no zones" do
+      {:ok, sm} = ShippingMethod.create(@valid_params, [])
+      assert [] = sm.zones
+    end
+  end
+
+  describe "update" do
+    setup :shipping_methods
+
+    @tag shipping_method_count: 1, state_zone_count: 1, country_zone_count: 1
+    test "only params", %{shipping_methods: [sm]} do
+      new_params = %{name: "bullock-cart"}
+      {:ok, updated_sm} = ShippingMethod.update(sm, new_params, sm.zones)
+      assert sm.zones == updated_sm.zones
+      assert updated_sm.name == "bullock-cart"
+    end
+
+    @tag shipping_method_count: 1, state_zone_count: 1, country_zone_count: 1
+    test "remove all zones", %{shipping_methods: [sm]} do
+      new_params = %{name: "bullock-cart"}
+      {:ok, updated_sm} = ShippingMethod.update(sm, new_params, [])
+      assert [] = updated_sm.zones
+    end
+
+    @tag shipping_method_count: 1, state_zone_count: 1, country_zone_count: 1
+    test "params and zones", %{shipping_methods: [sm]} do
+      new_params = %{name: "bullock-cart"}
+      {:ok, updated_sm} = ShippingMethod.update(sm, new_params, [])
+      assert [] = updated_sm.zones
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/shipping_method_test.exs
+++ b/apps/snitch_core/test/data/schema/shipping_method_test.exs
@@ -47,7 +47,7 @@ defmodule Snitch.Data.Schema.ShippingMethodTest do
     @tag state_zone_count: 1, country_zone_count: 1
     test "allow zones of different types", %{zones: zones} do
       %{valid?: validity} =
-        changeset = ShippingMethod.changeset(%ShippingMethod{}, @valid_params, zones, :create)
+        ShippingMethod.changeset(%ShippingMethod{}, @valid_params, zones, :create)
 
       assert validity
     end

--- a/apps/snitch_core/test/data/schema/shipping_method_test.exs
+++ b/apps/snitch_core/test/data/schema/shipping_method_test.exs
@@ -1,0 +1,88 @@
+defmodule Snitch.Data.Schema.ShippingMethodTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Schema.ShippingMethod
+
+  @valid_params %{
+    slug: "shipping-method-0",
+    name: "FREE One Day delivery",
+    description: "*Conditions apply :)"
+  }
+
+  @tag state_zone_count: 3
+  describe "create shipping_method" do
+    setup :zones
+
+    test "changeset with valid params and zones", %{zones: zones} do
+      %{valid?: validity} =
+        changeset = ShippingMethod.changeset(%ShippingMethod{}, @valid_params, zones, :create)
+
+      assert validity
+      assert Enum.all?(changeset.changes.zones, fn cset -> cset.action == :update end)
+    end
+
+    test "changeset with valid params and no zones" do
+      %{valid?: validity} =
+        ShippingMethod.changeset(%ShippingMethod{}, @valid_params, [], :create)
+
+      assert validity
+    end
+
+    test "name, slug, description cannot be blank", %{zones: zones} do
+      %{valid?: validity} =
+        changeset = ShippingMethod.changeset(%ShippingMethod{}, %{}, zones, :create)
+
+      refute validity
+
+      assert %{
+               description: ["can't be blank"],
+               name: ["can't be blank"],
+               slug: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    @tag state_zone_count: 1, country_zone_count: 1
+    test "allow zones of different types", %{zones: zones} do
+      %{valid?: validity} =
+        changeset = ShippingMethod.changeset(%ShippingMethod{}, @valid_params, zones, :create)
+
+      assert validity
+    end
+  end
+
+  @tag country_zone_count: 3
+  describe "update shipping_method" do
+    setup :zones
+    setup :shipping_method
+
+    test "slugs must be unique" do
+      cs = ShippingMethod.changeset(%ShippingMethod{}, @valid_params, [], :create)
+      assert {:error, changeset} = Repo.insert(cs)
+      assert %{slug: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "allow zones to be replaced", %{shipping_method: sm} do
+      [zones: new_zones] = zones(%{country_zone_count: 2})
+
+      cs = %{valid?: validity} = ShippingMethod.changeset(sm, %{}, new_zones, :update)
+      assert validity
+      assert Enum.all?(cs.changes.zones, fn cset -> cset.action == :update end)
+      assert {:ok, _} = Repo.update(cs)
+    end
+
+    test "allow zones to be removed", %{shipping_method: sm} do
+      cs = %{valid?: validity} = ShippingMethod.changeset(sm, %{}, [], :update)
+      assert validity
+      assert {:ok, _} = Repo.update(cs)
+    end
+  end
+
+  defp shipping_method(%{zones: zones}) do
+    cs = ShippingMethod.changeset(%ShippingMethod{}, @valid_params, zones, :create)
+    {:ok, sm} = Repo.insert(cs)
+    [shipping_method: sm]
+  end
+end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -2,7 +2,7 @@ defmodule Snitch.Factory do
   @moduledoc false
 
   use ExMachina.Ecto, repo: Snitch.Repo
-  use Snitch.Factory.{Address, Stock, Zone}
+  use Snitch.Factory.{Address, Stock, Zone, Shipping}
 
   alias Snitch.Data.Schema.{Variant, Address, User, Order, Payment, PaymentMethod, CardPayment}
 

--- a/apps/snitch_core/test/support/factory/shipping.ex
+++ b/apps/snitch_core/test/support/factory/shipping.ex
@@ -1,0 +1,25 @@
+defmodule Snitch.Factory.Shipping do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Snitch.Data.Schema.{ShippingMethod}
+
+      def shipping_method_factory do
+        %ShippingMethod{
+          slug: sequence("shipping_method"),
+          name: sequence("hyperloop"),
+          description: "Brought to you by spacex!"
+        }
+      end
+
+      def shipping_methods(%{zones: zones} = context) do
+        sm_count = Map.get(context, :shipping_method_count, 0)
+
+        [
+          shipping_methods: insert_list(sm_count, :shipping_method, zones: zones)
+        ]
+      end
+    end
+  end
+end

--- a/apps/snitch_core/test/support/factory/zone.ex
+++ b/apps/snitch_core/test/support/factory/zone.ex
@@ -7,9 +7,20 @@ defmodule Snitch.Factory.Zone do
 
       def zone_factory do
         %Zone{
-          name: sequence("area", fn area_code -> "-#{area_code + 50}" end),
+          name: sequence(:area, fn area_code -> "area-#{area_code + 50}" end),
           description: "Does area-51 exist?"
         }
+      end
+
+      def zones(context) do
+        sz_count = Map.get(context, :state_zone_count, 0)
+        cz_count = Map.get(context, :country_zone_count, 0)
+
+        [
+          zones:
+            insert_list(sz_count, :zone, zone_type: "S") ++
+              insert_list(cz_count, :zone, zone_type: "C")
+        ]
       end
     end
   end

--- a/apps/snitch_core/test/support/factory/zone.ex
+++ b/apps/snitch_core/test/support/factory/zone.ex
@@ -7,7 +7,7 @@ defmodule Snitch.Factory.Zone do
 
       def zone_factory do
         %Zone{
-          name: sequence(:area, fn area_code -> "area-#{area_code + 50}" end),
+          name: sequence(:area, fn area_code -> "area-#{area_code + 51}" end),
           description: "Does area-51 exist?"
         }
       end


### PR DESCRIPTION
### `ShippingMethod`

**[Pivotal Story](https://www.pivotaltracker.com/story/show/155972979)**
* A `shipping_method` may have zero or more zones.
* Zones can be associated ONLY by providing a list of zone structs. A list of zone_ids will not suffice.
  - That's how [`put_assoc`](https://hexdocs.pm/ecto/Ecto.Changeset.html#put_assoc/4) works in a many-to-many relation.
* `shipping_method` cannot have duplicate zones.
* `shipping_method` can have zones of different types.

### Tests
Because both `create` and `update` work with `Zone` structs, there are no tests for the scenario when caller passes "bad" zone structs.