### PR TITLE
Add selling_price to Variant, and tests

### DIFF
--- a/apps/snitch_core/lib/core/data/model/line_item.ex
+++ b/apps/snitch_core/lib/core/data/model/line_item.ex
@@ -36,13 +36,13 @@ defmodule Snitch.Data.Model.LineItem do
   When both `variant_id` and `quantity` are valid, update is made.
   ```
   iex> variant = Snitch.Repo.one(Snitch.Data.Schema.Variant)
-  iex> variant.cost_price
-  #Money<:USD, 9.99000000>
+  iex> variant.selling_price
+  #Money<:USD, 14.99000000>
   iex> [priced_item] = Model.LineItem.update_price_and_totals(
   ...>   [%{variant_id: variant.id, quantity: 2}]
   ...> )
   iex> priced_item.total
-  #Money<:USD, 19.98000000>
+  #Money<:USD, 29.98000000>
   ```
   """
   @spec update_price_and_totals([map]) :: [map]

--- a/apps/snitch_core/lib/core/data/schema/payment/payment.ex
+++ b/apps/snitch_core/lib/core/data/schema/payment/payment.ex
@@ -35,7 +35,7 @@ defmodule Snitch.Data.Schema.Payment do
     payment
     |> cast(params, @create_fields)
     |> validate_required(@create_fields)
-    |> validate_discriminator(:payment_type, @payment_types)
+    |> validate_inclusion(:payment_type, @payment_types)
     |> foreign_key_constraint(:payment_method_id)
     |> common_changeset()
   end
@@ -62,30 +62,4 @@ defmodule Snitch.Data.Schema.Payment do
     |> validate_amount(:amount)
     |> unique_constraint(:slug)
   end
-
-  @spec validate_discriminator(Ecto.Changeset.t(), atom, list) :: Ecto.Changeset.t()
-  defp validate_discriminator(%Ecto.Changeset{valid?: true} = changeset, key, permitted) do
-    {_, discriminator} = fetch_field(changeset, key)
-
-    if discriminator in permitted do
-      changeset
-    else
-      add_error(changeset, :payment_type, "'#{discriminator}' is invalid", validation: :inclusion)
-    end
-  end
-
-  defp validate_discriminator(changeset, _, _), do: changeset
-
-  @spec validate_amount(Ecto.Changeset.t(), atom) :: Ecto.Changeset.t()
-  defp validate_amount(%Ecto.Changeset{valid?: true} = changeset, key) do
-    {_, amount} = fetch_field(changeset, key)
-
-    if Decimal.cmp(amount.amount, Decimal.new(0)) != :lt do
-      changeset
-    else
-      add_error(changeset, :amount, "must be greater than 0", validation: :amount)
-    end
-  end
-
-  defp validate_amount(changeset, _), do: changeset
 end

--- a/apps/snitch_core/lib/core/data/schema/schema.ex
+++ b/apps/snitch_core/lib/core/data/schema/schema.ex
@@ -7,6 +7,7 @@ defmodule Snitch.Data.Schema do
     quote do
       use Ecto.Schema
       import Ecto.Changeset
+      import Snitch.Tools.Validations
     end
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/zone.ex
@@ -42,22 +42,10 @@ defmodule Snitch.Data.Schema.Zone do
     zone
     |> cast(params, @create_fields)
     |> validate_required(@create_fields)
-    |> validate_discriminator(:zone_type, @valid_zone_types)
+    |> validate_inclusion(:zone_type, @valid_zone_types)
   end
 
   def changeset(zone, params, :update) do
     cast(zone, params, @update_fields)
-  end
-
-  defp validate_discriminator(%{valid?: false} = changeset, _, _), do: changeset
-
-  defp validate_discriminator(%{valid?: true} = changeset, key, permitted) do
-    {_, discriminator} = fetch_field(changeset, key)
-
-    if discriminator in permitted do
-      changeset
-    else
-      add_error(changeset, :zone_type, "'#{discriminator}' is invalid", validation: :inclusion)
-    end
   end
 end

--- a/apps/snitch_core/lib/core/tools/validations.ex
+++ b/apps/snitch_core/lib/core/tools/validations.ex
@@ -1,0 +1,60 @@
+defmodule Snitch.Tools.Validations do
+  @moduledoc """
+  A bunch of data validations for `Ecto.Changeset`.
+
+  ## Note
+
+  All validations in this module are check ONLY the value present under the
+  `:changes` key in the `Ecto.Changeset.t()`.
+
+  The validations are non-strict, and will not complain if the key is not
+  present under `:changes`.
+  """
+
+  import Ecto.Changeset
+
+  @doc """
+  Validates that the amount (of type `Money.t`) under the `key` in `changeset`
+  is non-negative.
+  """
+  @spec validate_amount(Ecto.Changeset.t(), atom) :: Ecto.Changeset.t()
+  def validate_amount(%Ecto.Changeset{valid?: true} = changeset, key) when is_atom(key) do
+    case fetch_change(changeset, key) do
+      {:ok, %Money{amount: amount}} ->
+        if Decimal.cmp(amount, Decimal.new(0)) != :lt do
+          changeset
+        else
+          add_error(changeset, key, "must be greater than 0", validation: :number)
+        end
+
+      :error ->
+        changeset
+    end
+  end
+
+  def validate_amount(changeset, _), do: changeset
+
+  @doc """
+  Validates that the given date (of type `DateTime.t`) under the `key` in
+  `changeset` is in the future wrt. `DateTime.utc_now/0`.
+  """
+  @spec validate_future_date(Ecto.Changeset.t(), atom) :: Ecto.Changeset.t()
+  def validate_future_date(%Ecto.Changeset{valid?: true} = changeset, key)
+      when is_atom(key) do
+    case fetch_change(changeset, key) do
+      {:ok, date} ->
+        current_time = DateTime.utc_now()
+
+        if DateTime.compare(date, current_time) == :gt do
+          changeset
+        else
+          add_error(changeset, key, "date should be in future", validation: :number)
+        end
+
+      :error ->
+        changeset
+    end
+  end
+
+  def validate_future_date(changeset, _), do: changeset
+end

--- a/apps/snitch_core/priv/repo/migrations/20180210100730_create_variant_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180210100730_create_variant_table.exs
@@ -13,7 +13,7 @@ defmodule Core.Repo.Migrations.CreateVariantTable do
       add :position, :integer
       add :cost_currency, :string
       add :track_inventory, :boolean, default: true
-      add :discontinue_on, :naive_datetime
+      add :discontinue_on, :utc_datetime
 
       # Not adding any association ids
       timestamps()

--- a/apps/snitch_core/priv/repo/migrations/20180425115545_add_prices_to_variants.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180425115545_add_prices_to_variants.exs
@@ -1,0 +1,16 @@
+defmodule Snitch.Repo.Migrations.AddPricesToVariants do
+  use Ecto.Migration
+
+  # cost_price, selling_price need to be not-null
+  # sku default made absolutely no sense (since it has to be unique)
+  # defaults are a bad idea in general (weight default removed)
+  def change do
+    alter table(:snitch_variants) do
+      remove :is_master
+      add :selling_price, :money_with_currency, null: false
+      modify :cost_price, :money_with_currency, null: false
+      modify :sku, :string, null: false
+      modify :weight, :decimal, precision: 8, scale: 2
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/payment_methods.ex
+++ b/apps/snitch_core/priv/repo/seed/payment_methods.ex
@@ -2,26 +2,20 @@ defmodule Snitch.Seed.PaymentMethods do
   @moduledoc """
   Seeds supported PaymentMethods.
 
-  Snitch comes with two payment methods built-in:
-  1. check or cash
-  2. credit or debit cards
-
-  ## Check or Cash
-
-  This payment method is backed only by the `Core.Snitch.Data.Schema.Payments`
-  schema.
+  Snitch comes with some payment methods built-in:
+  1. credit or debit cards
 
   ## Cards
 
-  This payment method is backed by the `Core.Snitch.Data.Schema.CardPayments`
+  This payment method is backed by the `Snitch.Data.Schema.CardPayments`
   schema and table.
 
   ## Roadmap
 
   Snitch will support "Store Credits", which act like e-wallets for users.
   """
-  alias Snitch.Data.Schema.PaymentMethod
 
+  alias Snitch.Data.Schema.PaymentMethod
   alias Snitch.Repo
 
   def seed!() do

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -13,7 +13,6 @@ defmodule Snitch.Data.Model.LineItemTest do
     test "update_price_and_totals/1", context do
       %{line_items: line_items, totals: totals} = context
       priced_items = LineItem.update_price_and_totals(line_items)
-
       assert Enum.all?(priced_items, fn x -> totals[x.variant_id] == Money.reduce(x.total) end)
     end
 
@@ -63,7 +62,7 @@ defmodule Snitch.Data.Model.LineItemTest do
       |> Enum.reduce({[], %{}}, fn {variant, quantity}, {ls, ts} ->
         {
           [%{variant_id: variant.id, quantity: quantity} | ls],
-          Map.put(ts, variant.id, Money.mult!(variant.cost_price, quantity))
+          Map.put(ts, variant.id, Money.mult!(variant.selling_price, quantity))
         }
       end)
 

--- a/apps/snitch_core/test/data/schema/payment/payment_test.exs
+++ b/apps/snitch_core/test/data/schema/payment/payment_test.exs
@@ -15,11 +15,11 @@ defmodule Snitch.Data.Schema.PaymentTest do
 
     check_payment =
       :payment_chk
-      |> build(payment_type: "abc", payment_method_id: method.id, order_id: order.id)
-      |> Payment.create_changeset(%{})
+      |> build(payment_method_id: method.id, order_id: order.id)
+      |> Payment.create_changeset(%{payment_type: "abc"})
 
     assert %Ecto.Changeset{errors: errors} = check_payment
-    assert errors == [payment_type: {"'abc' is invalid", [validation: :inclusion]}]
+    assert errors == [payment_type: {"is invalid", [validation: :inclusion]}]
   end
 
   test "Payments cannot have negative amount", context do
@@ -31,6 +31,6 @@ defmodule Snitch.Data.Schema.PaymentTest do
       |> Payment.create_changeset(%{amount: Money.new("-0.0001", :USD)})
 
     assert %Ecto.Changeset{errors: errors} = check_payment
-    assert errors == [amount: {"must be greater than 0", [validation: :amount]}]
+    assert errors == [amount: {"must be greater than 0", [validation: :number]}]
   end
 end

--- a/apps/snitch_core/test/data/schema/zone/zone_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/zone_test.exs
@@ -5,10 +5,10 @@ defmodule Snitch.Data.Schema.ZoneTest do
   alias Snitch.Data.Schema.Zone
 
   test "Zone invalidates bad type" do
-    params = %{name: "foobar", description: "non-existent"}
-    zone = Zone.changeset(%Zone{zone_type: "x"}, params, :create)
+    params = %{name: "foobar", description: "non-existent", zone_type: "x"}
+    zone = Zone.changeset(%Zone{}, params, :create)
 
     assert %Ecto.Changeset{errors: errors} = zone
-    assert errors == [zone_type: {"'x' is invalid", [validation: :inclusion]}]
+    assert errors == [zone_type: {"is invalid", [validation: :inclusion]}]
   end
 end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -34,8 +34,8 @@ defmodule Snitch.Factory do
       height: Decimal.new("0.15"),
       depth: Decimal.new("0.1"),
       width: Decimal.new("0.4"),
-      is_master: true,
-      cost_price: random_price(9, 9)
+      cost_price: Money.new("9.99", :USD),
+      selling_price: random_price(14, 4)
     }
   end
 
@@ -46,8 +46,8 @@ defmodule Snitch.Factory do
       height: Decimal.new("0.15"),
       depth: Decimal.new("0.1"),
       width: Decimal.new("0.4"),
-      is_master: true,
-      cost_price: Money.new("9.99", :USD)
+      cost_price: Money.new("9.99", :USD),
+      selling_price: Money.new("14.99", :USD)
     }
   end
 
@@ -174,5 +174,15 @@ defmodule Snitch.Factory do
     %{user: user} = context
     card_count = Map.get(context, :card_count, 1)
     [cards: insert_list(card_count, :card, user_id: user.id)]
+  end
+
+  def offset_date_by(date, offset_days) do
+    {:ok, time} =
+      date
+      |> DateTime.to_unix()
+      |> (&(&1 + offset_days * 60 * 60 * 24)).()
+      |> DateTime.from_unix()
+
+    time
   end
 end


### PR DESCRIPTION
* Modified `discontinue_on` type from `naive_datetime` 
to `utc_datetime`, added validation.
* Added tests for the variant schema.
* Update `line_item` and `payment` tests.