### PR TITLE
Add user, address, variant, order, lineitem seed data

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,7 +3,7 @@
     "apps/*/{lib,config}/**/*.{ex,exs}", # lib and config
     "apps/*/test/**/*.{ex,exs}", # tests
     # "apps/*/priv/repo/migrations/*.{ex,exs}", # migrations
-    "apps/*/priv/repo/*.{ex,exs}", # seeds
+    "apps/*/priv/repo/seed/*.{ex,exs}", # seeds
     "apps/*/mix.exs", # mix files
     "mix.exs", # top-level
   ]

--- a/apps/snitch_core/coveralls.json
+++ b/apps/snitch_core/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "skip_files": [
+    "priv/repo/seed/"
+  ]
+}

--- a/apps/snitch_core/lib/core/data/schema/address.ex
+++ b/apps/snitch_core/lib/core/data/schema/address.ex
@@ -21,6 +21,7 @@ defmodule Snitch.Data.Schema.Address do
     field(:phone, :string)
     field(:alternate_phone, :string)
 
+    # TODO: associate address with state and country
     # has_one :state, State
     # has_one :country, Country
     timestamps()

--- a/apps/snitch_core/lib/core/data/schema/order.ex
+++ b/apps/snitch_core/lib/core/data/schema/order.ex
@@ -79,6 +79,7 @@ defmodule Snitch.Data.Schema.Order do
   @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp common_changeset(order_changeset) do
     order_changeset
+    |> unique_constraint(:slug)
     |> foreign_key_constraint(:billing_address_id)
     |> foreign_key_constraint(:shipping_address_id)
   end

--- a/apps/snitch_core/priv/repo/migrations/20180501173309_order_slug_unique_index.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180501173309_order_slug_unique_index.exs
@@ -1,0 +1,7 @@
+defmodule Snitch.Repo.Migrations.OrderSlugUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    create unique_index("snitch_orders", :slug)
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/orders.ex
+++ b/apps/snitch_core/priv/repo/seed/orders.ex
@@ -1,0 +1,153 @@
+defmodule Snitch.Seed.Orders do
+  @moduledoc false
+
+  alias Ecto.DateTime
+  alias Snitch.Repo
+  alias Snitch.Data.Schema.{Variant, Order, Address, User, LineItem}
+
+  @line_item %{
+    variant_id: nil,
+    order_id: nil,
+    quantity: nil,
+    unit_price: nil,
+    total: nil,
+    inserted_at: DateTime.utc(),
+    updated_at: DateTime.utc()
+  }
+
+  @order %{
+    slug: nil,
+    state: nil,
+    billing_address_id: nil,
+    shipping_address_id: nil,
+    user_id: nil,
+    adjustment_total: Money.new(0, :USD),
+    promo_total: Money.new(0, :USD),
+    item_total: Money.new(0, :USD),
+    total: Money.new(0, :USD),
+    inserted_at: DateTime.utc(),
+    updated_at: DateTime.utc()
+  }
+
+  @variant_count 5
+  @max_line_item_count 3
+
+  def seed_orders! do
+    variants = Repo.all(Variant)
+    [address | _] = Repo.all(Address)
+    [user | _] = Repo.all(User)
+
+    digest = %{
+      cart: [user_id: user.id],
+      address: [user_id: user.id, address_id: address.id],
+      payment: [user_id: user.id, address_id: address.id]
+    }
+
+    {orders, line_items} = make_orders(digest, variants)
+
+    {_, order_structs} =
+      Repo.insert_all(
+        Order,
+        orders,
+        on_conflict: :nothing,
+        conflict_target: [:slug],
+        returning: [:id, :slug]
+      )
+
+    filtered_line_items =
+      order_structs
+      |> Enum.map(fn %{id: id, slug: slug} ->
+        line_items
+        |> Enum.reduce(&Map.merge/2)
+        |> Map.fetch!(slug)
+        |> Stream.map(&Map.put(&1, :order_id, id))
+        |> Enum.map(&Map.delete(&1, :slug))
+      end)
+      |> List.flatten()
+
+    Repo.insert_all(LineItem, filtered_line_items)
+  end
+
+  def make_orders(digest, variants) do
+    digest
+    |> Enum.map(fn {state, opts} ->
+      slug = "order-in-#{state}"
+
+      line_items =
+        variants
+        |> Enum.shuffle()
+        |> random_line_items()
+        |> Stream.map(&Map.put(&1, :slug, slug))
+        |> Enum.take(2 + :rand.uniform(3))
+
+      item_total =
+        line_items
+        |> Stream.map(&Map.fetch!(&1, :total))
+        |> Enum.reduce(&Money.add!/2)
+
+      order = %{
+        @order
+        | slug: slug,
+          state: "#{state}",
+          user_id: opts[:user_id],
+          billing_address_id: opts[:address_id],
+          shipping_address_id: opts[:address_id],
+          item_total: item_total,
+          total: item_total
+      }
+
+      {order, %{slug => line_items}}
+    end)
+    |> Enum.unzip()
+  end
+
+  def random_line_items(variants) do
+    Stream.map(variants, fn v ->
+      quantity = :rand.uniform(3)
+
+      %{
+        @line_item
+        | variant_id: v.id,
+          quantity: quantity,
+          unit_price: v.selling_price,
+          total: Money.mult!(v.selling_price, quantity)
+      }
+    end)
+  end
+
+  def seed_variants!(count \\ nil) do
+    Repo.insert_all(
+      Variant,
+      Enum.take(variants(), count || @variant_count),
+      returning: [:id],
+      on_conflict: :nothing
+    )
+  end
+
+  def variants do
+    0
+    |> Stream.iterate(&(&1 + 1))
+    |> Stream.map(&"shoes-nike-#{&1}")
+    |> Stream.map(fn sku -> %{random_variant() | sku: sku} end)
+  end
+
+  def random_variant do
+    price = random_price(9, 19)
+
+    %{
+      sku: nil,
+      weight: Decimal.new("0.45"),
+      height: Decimal.new("0.15"),
+      depth: Decimal.new("0.1"),
+      width: Decimal.new("0.4"),
+      selling_price: price,
+      cost_price: Money.sub!(price, Money.new("1.499", :USD)),
+      inserted_at: DateTime.utc(),
+      updated_at: DateTime.utc()
+    }
+  end
+
+  defp random_price(min, delta) do
+    Money.new(:USD, "#{:rand.uniform(delta) + min}.99")
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/seeds.exs
+++ b/apps/snitch_core/priv/repo/seed/seeds.exs
@@ -1,3 +1,5 @@
+alias Snitch.Repo
+alias Snitch.Seed.{CountryState, PaymentMethods, Orders, Users}
 # Script for populating the database. You can run it as:
 #
 #     mix run priv/repo/seeds.exs
@@ -11,7 +13,15 @@
 # and so on) as they will fail if something goes wrong.
 
 # seeds countries and states entity
-Snitch.Seed.CountryState.seed_countries_and_states!()
+CountryState.seed_countries_and_states!()
 
 # seed payment methods
-Snitch.Seed.PaymentMethods.seed!()
+PaymentMethods.seed!()
+
+Users.seed_address!()
+Users.seed_users!()
+
+Repo.transaction(fn ->
+  Orders.seed_variants!(11)
+  Orders.seed_orders!()
+end)

--- a/apps/snitch_core/priv/repo/seed/users.ex
+++ b/apps/snitch_core/priv/repo/seed/users.ex
@@ -1,0 +1,46 @@
+defmodule Snitch.Seed.Users do
+  @moduledoc false
+
+  alias Snitch.Repo
+  alias Ecto.DateTime
+  alias Snitch.Data.Schema.{User, Address}
+  alias Comeonin.Argon2
+
+  @user_passwd Argon2.hashpwsalt("avenger")
+  @admin_passwd Argon2.hashpwsalt("wizard")
+
+  @address %Address{
+    first_name: "Tony",
+    last_name: "Stark",
+    address_line_1: "10-8-80 Malibu Point",
+    zip_code: "90265",
+    city: "Malibu",
+    phone: "1234567890"
+  }
+
+  def seed_users! do
+    users = [
+      user("Harry", "Potter", "admin@snitch.com", @admin_passwd, true),
+      user("Tony", "Stark", "tony@snitch.com", @user_passwd),
+      user("Steven", "Rogers", "steven@snitch.com", @user_passwd)
+    ]
+
+    Repo.insert_all(User, users, on_conflict: :nothing, conflict_target: [:email])
+  end
+
+  def user(first_name, last_name, email, pwd_hash, admin \\ false) do
+    %{
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      password_hash: pwd_hash,
+      is_admin: admin,
+      inserted_at: DateTime.utc(),
+      updated_at: DateTime.utc()
+    }
+  end
+
+  def seed_address! do
+    Repo.insert!(@address)
+  end
+end


### PR DESCRIPTION
**Used only `insert_all` for inserts to guarantee speed and handle constraint conflicts.**

* There's some randomness, just for giggles :hibiscus:
* Oops, order slug had no unique constraint, fixed that.

[Delivers #157229687](https://www.pivotaltracker.com/story/show/157229687).