### PR TITLE
Add TaxCategory model and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover/
+/apps/*/cover/
 
 # The directory Mix downloads your dependencies sources to.
 /deps/

--- a/apps/snitch_core/lib/core/data/model/tax_category.ex
+++ b/apps/snitch_core/lib/core/data/model/tax_category.ex
@@ -1,0 +1,180 @@
+defmodule Snitch.Data.Model.TaxCategory do
+  @moduledoc """
+  Model functions Tax Category.
+  """
+  use Snitch.Data.Model
+
+  import Ecto.Changeset
+
+  alias Snitch.Data.Schema.TaxCategory
+  alias Ecto.Multi
+
+  @doc """
+  Creates a TaxCategory in the db with the supplied `params`.
+
+  To create, following fields can be provided in the params
+  map:
+
+  | field       | type     |
+  | ---------   |  ------  |
+  | name        | string   |
+  | tax_code    | string   | 
+  | description | string   |
+  | is_default? | boolean  |
+
+  > Note :name field in the params is a `required` field.
+  > If `:is_default?` field is set to `true` then the current tax_category 
+    is set as default and any previous tax category is unset from default. 
+  ## Example
+      params = %{
+        name: "Value Added Tax", 
+        tax_code: "EU_VAT", 
+        description: "value added tax"
+      }
+      {:ok, tax_category} = Snitch.Data.Model.TaxCategory.create(params)
+  """
+  @spec create(map) ::
+          {:ok, TaxCategory.t()}
+          | {:error, Ecto.Changeset.t()}
+  def create(params) do
+    changeset = TaxCategory.create_changeset(%TaxCategory{}, params)
+
+    case fetch_change(changeset, :is_default?) do
+      {:ok, true} ->
+        clear_default_multi()
+        |> Multi.run(:tax_category, fn _ ->
+          QH.create(TaxCategory, params, Repo)
+        end)
+        |> persist()
+
+      _ ->
+        QH.create(TaxCategory, params, Repo)
+    end
+  end
+
+  @doc """
+  Updates a tax category as per the supplied fields in params.
+
+  The following fields are updatable:
+
+  | field       | type     |
+  | ---------   |  ------  |
+  | name        | string   |
+  | tax_code    | string   | 
+  | description | string   |
+  | is_default  | boolean  |
+
+  ## Note
+
+  If the `:name` field is passed in `params` then it shouldn't be
+  empty.
+  If `:is_default?` field is set to `true` then the current `tax_category` 
+  is set as default and any previous tax category is unset from default.
+
+  ## Example 
+      create_params = %{
+        name: "Value Added Tax",
+        tax_code: "EU_VAT", 
+        description: "value added tax"
+      }
+      {:ok, tax_category} = Snitch.Data.Model.TaxCategory.create(create_params)
+
+      update_params = %{
+        name: "Value Added Tax", 
+        tax_code: "EU_VAT", 
+        description: "value added tax"
+      }
+      {:ok, tax_category} = 
+        Snitch.Data.Model.TaxCategory.update(tax_category, params)
+  """
+  @spec update(map, TaxCategory.t()) ::
+          {:ok, TaxCategory.t()}
+          | {:error, Ecto.Changeset.t()}
+  def update(params, instance \\ nil) do
+    with true <- Map.has_key?(params, :is_default?),
+         true <- params.is_default? do
+      clear_default_multi()
+      |> Multi.run(:tax_category, fn _ ->
+        QH.update(TaxCategory, params, instance, Repo)
+      end)
+      |> persist()
+    else
+      _ ->
+        QH.update(TaxCategory, params, instance, Repo)
+    end
+  end
+
+  @doc """
+  Returns a TaxCategory.
+
+  Takes as input 'id' field and an `active` flag.
+  When `active` is false, will return a TaxCategory even
+  if it's _soft deleted_.
+
+  > Note, By default tax category which is present in the table
+  and is __not soft deleted__ is returned.
+  """
+  @spec get(integer, boolean) :: TaxCategory.t() | nil
+  def get(id, active \\ true) do
+    if active do
+      query = from(tc in TaxCategory, where: is_nil(tc.deleted_at) and tc.id == ^id)
+      Repo.one(query)
+    else
+      QH.get(TaxCategory, id, Repo)
+    end
+  end
+
+  @doc """
+  Returns a `list` of available tax categories.
+
+  Takes an `active` field. When `active` is false, will
+  return all the tax_categories, including those which are
+  _soft deleted_.
+
+  > Note the function returns only those tax categories
+    which are not soft deleted by default or if `active` is
+    set to true.
+  """
+
+  @spec get_all(boolean) :: [TaxCategory.t()]
+  def get_all(active \\ true) do
+    if active do
+      query = from(tc in TaxCategory, where: is_nil(tc.deleted_at))
+      Repo.all(query)
+    else
+      Repo.all(TaxCategory)
+    end
+  end
+
+  @doc """
+  Soft deletes a TaxCategory passed to the function.
+
+  Takes as input the `instance` of the TaxCategory to be deleted.
+  """
+  @spec delete(TaxCategory.t()) ::
+          {:ok, TaxCategory.t()}
+          | {:error, Ecto.Changeset.t()}
+  def delete(instance) do
+    params = %{deleted_at: DateTime.utc_now()}
+
+    case QH.update(TaxCategory, params, instance, Repo) do
+      {:ok, changeset} -> {:ok, changeset}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp clear_default_multi do
+    query = from(tc in TaxCategory, where: tc.is_default? == true)
+    Multi.update_all(Multi.new(), :is_default, query, set: [is_default?: false])
+  end
+
+  defp persist(multi) do
+    case Repo.transaction(multi) do
+      {:ok, %{tax_category: tax_category}} ->
+        {:ok, tax_category}
+
+      {:error, _, _, _} = error ->
+        error
+    end
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/tax_category.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax_category.ex
@@ -1,0 +1,54 @@
+defmodule Snitch.Data.Schema.TaxCategory do
+  @moduledoc """
+  Models a Tax Category.
+
+  A TaxCategory has many TaxRates.
+  """
+  use Snitch.Data.Schema
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_tax_categories" do
+    field(:name, :string)
+    field(:description, :string)
+    field(:tax_code, :string)
+    field(:is_default?, :boolean, default: false)
+
+    field(:deleted_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @required_fields ~w(name)a
+  @optional_fields ~w(description tax_code is_default? deleted_at)a
+  @create_fields @optional_fields ++ @required_fields
+  @update_fields @optional_fields ++ @required_fields
+
+  @doc """
+  Returns a changeset to create a new TaxCategory.
+
+  > Note, :name is a required field and it should be unique.
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = tax_category, params) do
+    tax_category
+    |> cast(params, @create_fields)
+    |> common_changeset()
+  end
+
+  @doc """
+  Returns a changeset to update a TaxCategory.
+  """
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = tax_category, params) do
+    tax_category
+    |> cast(params, @update_fields)
+    |> common_changeset()
+  end
+
+  defp common_changeset(changeset) do
+    changeset
+    |> validate_required(@required_fields)
+    |> unique_constraint(:name)
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180501173446_add_tax_category_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180501173446_add_tax_category_table.exs
@@ -1,0 +1,21 @@
+defmodule Snitch.Repo.Migrations.AddTaxCategoryTable do
+  use Ecto.Migration
+
+  def up do
+    create table(:snitch_tax_categories) do
+      add :name, :string
+      add :description, :string
+      add :tax_code, :string
+      add :is_default?, :boolean, default: false
+      add :deleted_at, :utc_datetime, default: nil
+
+      timestamps()
+    end
+    create unique_index(:snitch_tax_categories, [:name], where: "deleted_at is null")
+  end
+
+  def down do
+    drop unique_index(:snitch_tax_categories, [:name], where: "deleted_at is null")
+    drop table(:snitch_tax_categories)
+  end
+end

--- a/apps/snitch_core/test/data/model/tax_category_test.exs
+++ b/apps/snitch_core/test/data/model/tax_category_test.exs
@@ -1,0 +1,161 @@
+defmodule Snitch.Data.Model.TaxCategoryTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+  alias Snitch.Data.Model
+  alias Snitch.Data.Schema.TaxCategory
+
+  @valid_params %{
+    name: "EU_VAT",
+    description: "vat tax",
+    tax_code: "EU101"
+  }
+
+  describe "create/1" do
+    test "tax category successfully" do
+      assert {:ok, _} = Model.TaxCategory.create(@valid_params)
+    end
+
+    test "fails, Why? name not present" do
+      params = Map.drop(@valid_params, [:name])
+      assert {:error, cs} = Model.TaxCategory.create(params)
+      assert %{name: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "a default tax category" do
+      params = Map.put(@valid_params, :is_default?, true)
+      assert {:ok, tc} = Model.TaxCategory.create(params)
+      assert tc.is_default?
+    end
+
+    test "fails, Why? duplicate name" do
+      tc = insert(:tax_category)
+      params = %{@valid_params | name: tc.name}
+      assert {:error, cs} = Model.TaxCategory.create(params)
+      assert %{name: ["has already been taken"]} = errors_on(cs)
+    end
+
+    test "without conflict with soft deleted tax category" do
+      assert {:ok, tc} = Model.TaxCategory.create(@valid_params)
+      assert {:ok, _} = Model.TaxCategory.delete(tc)
+      assert {:ok, _} = Model.TaxCategory.create(@valid_params)
+    end
+
+    test "set a new default, unset older one" do
+      params = Map.put(@valid_params, :is_default?, true)
+      assert {:ok, tc} = Model.TaxCategory.create(params)
+      assert tc.is_default?
+
+      params =
+        %{@valid_params | name: "US_VAT"}
+        |> Map.put(:is_default?, true)
+
+      assert {:ok, tc_new} = Model.TaxCategory.create(params)
+      assert tc_new.is_default?
+      tc_old = Repo.get(TaxCategory, tc.id)
+      refute tc_old.is_default?
+    end
+  end
+
+  describe "update/2" do
+    test "successful" do
+      tc = insert(:tax_category)
+      params = %{name: "US_VAT", tax_code: "US_VAT"}
+      assert {:ok, tc_updated} = Model.TaxCategory.update(params, tc)
+      assert tc.id == tc_updated.id
+      refute tc.name == tc_updated.name
+      refute tc.tax_code == tc_updated.tax_code
+    end
+
+    test "successful without instance" do
+      tc = insert(:tax_category)
+      params = %{id: tc.id, name: "US_VAT", tax_code: "US_VAT"}
+      assert {:ok, tc_updated} = Model.TaxCategory.update(params)
+      assert tc.id == tc_updated.id
+      refute tc.name == tc_updated.name
+      refute tc.tax_code == tc_updated.tax_code
+    end
+
+    test "unsuccessful, Why? name empty" do
+      tc = insert(:tax_category)
+      params = %{name: "", tax_code: "AU_V"}
+      assert {:error, cs} = Model.TaxCategory.update(params, tc)
+      assert %{name: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "set new default" do
+      params = Map.put(@valid_params, :is_default?, true)
+      assert {:ok, tc} = Model.TaxCategory.create(params)
+      assert tc.is_default?
+      tc_new = insert(:tax_category)
+      params = %{is_default?: true}
+      assert {:ok, tc_updated} = Model.TaxCategory.update(params, tc_new)
+      assert tc_updated.is_default?
+      tc_old = Repo.get(TaxCategory, tc.id)
+      refute tc_old.is_default?
+    end
+  end
+
+  describe "delete/1" do
+    test "tax category successfully" do
+      tc = insert(:tax_category)
+      assert {:ok, tc} = Model.TaxCategory.delete(tc)
+      refute is_nil(tc.deleted_at)
+      tc_deleted = Repo.get(TaxCategory, tc.id)
+      refute is_nil(tc_deleted)
+    end
+  end
+
+  describe "get_all" do
+    setup :tax_categories
+
+    @tag tax_category_count: 2
+    test "tax categories" do
+      tax_categories = Model.TaxCategory.get_all()
+      assert length(tax_categories) == 2
+      assert {:ok, _} = Model.TaxCategory.delete(List.first(tax_categories))
+      tax_categories = Model.TaxCategory.get_all()
+      assert length(tax_categories) == 1
+    end
+
+    @tag tax_category_count: 2
+    test "tax categories including, soft deleted" do
+      tax_categories = Model.TaxCategory.get_all()
+      assert length(tax_categories) == 2
+      assert {:ok, _} = Model.TaxCategory.delete(List.first(tax_categories))
+      tax_categories = Model.TaxCategory.get_all(false)
+      assert length(tax_categories) == 2
+    end
+
+    test "tax categories for no record" do
+      Repo.delete_all(TaxCategory)
+      tax_categories = Model.TaxCategory.get_all()
+      assert tax_categories == []
+    end
+  end
+
+  describe "get/2" do
+    test "tax category" do
+      tc = insert(:tax_category)
+      tc_ret = Model.TaxCategory.get(tc.id)
+      assert tc.id == tc_ret.id
+    end
+
+    test "no tax category, is deleted" do
+      tc = insert(:tax_category)
+      assert {:ok, tc} = Model.TaxCategory.delete(tc)
+      refute is_nil(tc.deleted_at)
+      tc_ret = Model.TaxCategory.get(tc.id)
+      assert is_nil(tc_ret)
+    end
+
+    test "tax category, is deleted" do
+      tc = insert(:tax_category)
+      {:ok, tc} = Model.TaxCategory.delete(tc)
+      refute is_nil(tc.deleted_at)
+      tc_ret = Model.TaxCategory.get(tc.id, false)
+      refute is_nil(tc_ret)
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/tax_category_test.exs
+++ b/apps/snitch_core/test/data/schema/tax_category_test.exs
@@ -1,0 +1,71 @@
+defmodule Snitch.Data.Schema.TaxCategoryTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Repo
+  alias Snitch.Data.Schema.TaxCategory
+
+  @valid_params %{
+    name: "EU_VAT",
+    description: "vat tax",
+    tax_code: "EU101"
+  }
+
+  describe "creation" do
+    test "with valid params" do
+      changeset =
+        %{valid?: validity} = TaxCategory.create_changeset(%TaxCategory{}, @valid_params)
+
+      assert validity
+      assert {:ok, _} = Repo.insert(changeset)
+    end
+
+    test "as default category" do
+      params = Map.put(@valid_params, :is_default?, true)
+      changeset = %{valid?: validity} = TaxCategory.create_changeset(%TaxCategory{}, params)
+      assert validity
+      assert {:ok, tc} = Repo.insert(changeset)
+      assert tc.is_default?
+    end
+
+    test "fails, Why? duplicate name" do
+      tc = insert(:tax_category)
+      params = %{@valid_params | name: tc.name}
+      changeset = TaxCategory.create_changeset(%TaxCategory{}, params)
+      assert {:error, cs} = Repo.insert(changeset)
+      assert %{name: ["has already been taken"]} = errors_on(cs)
+    end
+
+    test "fails, Why? missing required params" do
+      params = Map.drop(@valid_params, [:name])
+      changeset = %{valid?: validity} = TaxCategory.create_changeset(%TaxCategory{}, params)
+      refute validity
+      assert %{name: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+
+  describe "updation" do
+    test "update category" do
+      tc = insert(:tax_category)
+
+      params = %{name: "US_VAT", description: "vat new"}
+      cs = %{valid?: validity} = TaxCategory.update_changeset(tc, params)
+      assert validity
+      {:ok, tc_new} = Repo.update(cs)
+      assert tc.id == tc_new.id
+      refute tc.name == tc_new.name
+      refute tc.description == tc_new.description
+    end
+
+    test "fails, duplicate name" do
+      tc1 = insert(:tax_category)
+      tc2 = insert(:tax_category, %{is_default?: true})
+      params = %{name: tc1.name}
+      cs = TaxCategory.update_changeset(tc2, params)
+      assert {:error, error_cs} = Repo.update(cs)
+      assert %{name: ["has already been taken"]} = errors_on(error_cs)
+    end
+  end
+end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -13,7 +13,8 @@ defmodule Snitch.Factory do
     Payment,
     PaymentMethod,
     CardPayment,
-    Card
+    Card,
+    TaxCategory
   }
 
   alias Snitch.Repo
@@ -110,6 +111,16 @@ defmodule Snitch.Factory do
     }
   end
 
+  def tax_category_factory do
+    %TaxCategory{
+      name: sequence(:name, ["CE_VAT", "GST", "CGST", "AU_VAT"]),
+      description: "tax applied",
+      is_default?: false,
+      tax_code: sequence(:tax_code, ["CE_1", "GST", "CGST", "AU_VAT"]),
+      deleted_at: nil
+    }
+  end
+
   defp random_price(min, delta) do
     Money.new(:USD, "#{:rand.uniform(delta) + min}.99")
   end
@@ -184,5 +195,10 @@ defmodule Snitch.Factory do
       |> DateTime.from_unix()
 
     time
+  end
+
+  def tax_categories(context) do
+    count = Map.get(context, :tax_category_count, 3)
+    [tax_categories: insert_list(count, :tax_category)]
   end
 end


### PR DESCRIPTION
This covers 
* Adding the tax category entity and related model functions.
* Have kept in soft delete for deleting a tax category and get_all tax_categories operations.