### PR TITLE
Finds the common zone of two addresses

### DIFF
--- a/apps/snitch_core/lib/core/data/schema/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/zone.ex
@@ -28,6 +28,7 @@ defmodule Snitch.Data.Schema.Zone do
     field(:name, :string)
     field(:description, :string)
     field(:zone_type, :string)
+    field(:members, :any, virtual: true)
     timestamps()
   end
 

--- a/apps/snitch_core/lib/core/domain/zone.ex
+++ b/apps/snitch_core/lib/core/domain/zone.ex
@@ -1,0 +1,28 @@
+defmodule Snitch.Domain.Zone do
+  @moduledoc """
+  Zone helpers.
+  """
+
+  use Snitch.Domain
+  alias Snitch.Data.Model.{StateZone, CountryZone}
+
+  @doc """
+  Returns the state and country zone `struct`s that are common to both addresses
+  in a tuple.
+
+  Format: `{common_state_zones, common_country_zones}`
+  """
+  @spec common(region_map, region_map) :: {state_zones :: [Zone.t()], country_zones :: [Zone.t()]}
+        when region_map: %{country_id: non_neg_integer}
+  def common(%{country_id: a_c_id} = a, %{country_id: b_c_id} = b)
+      when not (is_nil(a_c_id) or is_nil(b_c_id)) do
+    {
+      if is_nil(a.state_id) or is_nil(b.state_id) do
+        []
+      else
+        Repo.all(StateZone.common_zone_query(a.state_id, b.state_id))
+      end,
+      Repo.all(CountryZone.common_zone_query(a.country_id, b.country_id))
+    }
+  end
+end

--- a/apps/snitch_core/test/data/model/zone/country_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/country_zone_test.exs
@@ -21,7 +21,7 @@ defmodule Snitch.Data.Model.CountryZoneTest do
                  from(c in CountryZoneMember, where: c.zone_id == ^zone.id, select: c.country_id)
                )
 
-      assert country_ids == CountryZone.member_ids(zone.id)
+      assert country_ids == CountryZone.member_ids(zone)
     end
 
     test "fails if some states are invalid", %{countries: countries} do
@@ -41,12 +41,12 @@ defmodule Snitch.Data.Model.CountryZoneTest do
     setup :country_zone
 
     test "members/1 returns Country schemas", %{zone: zone, countries: countries} do
-      assert countries == CountryZone.members(zone.id)
+      assert countries == CountryZone.members(zone)
     end
 
     test "delete/1 removes all members too", %{zone: zone} do
       {:ok, _} = CountryZone.delete(zone)
-      assert [] = CountryZone.members(zone.id)
+      assert [] = CountryZone.members(zone)
     end
 
     test "update/3 succeeds with valid country_ids", %{zone: zone, countries: countries} do
@@ -54,7 +54,7 @@ defmodule Snitch.Data.Model.CountryZoneTest do
       old_country_ids = Enum.map(countries, &Map.get(&1, :id))
       new_country_ids = Enum.drop(old_country_ids, 1) ++ more_country_ids
       assert {:ok, _} = CountryZone.update(zone, %{}, new_country_ids)
-      country_ids = MapSet.new(CountryZone.member_ids(zone.id))
+      country_ids = MapSet.new(CountryZone.member_ids(zone))
 
       assert new_country_ids
              |> MapSet.new()
@@ -63,17 +63,17 @@ defmodule Snitch.Data.Model.CountryZoneTest do
 
     test "update/3 succeeds with no states", %{zone: zone} do
       assert {:ok, _} = CountryZone.update(zone, %{}, [])
-      assert [] = CountryZone.member_ids(zone.id)
+      assert [] = CountryZone.member_ids(zone)
     end
 
     test "update/3 fails with invalid states", %{zone: zone} do
-      old_country_ids = CountryZone.member_ids(zone.id)
+      old_country_ids = CountryZone.member_ids(zone)
 
       assert {:error, :added, %{errors: errors}, %{zone: updated_zone}} =
                CountryZone.update(zone, %{}, [-1])
 
       assert errors == [country_id: {"does not exist", []}]
-      assert old_country_ids == CountryZone.member_ids(updated_zone.id)
+      assert old_country_ids == CountryZone.member_ids(updated_zone)
     end
   end
 

--- a/apps/snitch_core/test/data/model/zone/state_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/state_zone_test.exs
@@ -21,7 +21,7 @@ defmodule Snitch.Data.Model.StateZoneTest do
                  from(s in StateZoneMember, where: s.zone_id == ^zone.id, select: s.state_id)
                )
 
-      assert state_ids == StateZone.member_ids(zone.id)
+      assert state_ids == StateZone.member_ids(zone)
     end
 
     test "fails if some states are invalid", %{states: states} do
@@ -42,14 +42,14 @@ defmodule Snitch.Data.Model.StateZoneTest do
 
     test "members/1 returns State schemas", %{zone: zone, states: states} do
       assert states ==
-               zone.id
+               zone
                |> StateZone.members()
                |> Enum.map(&Repo.preload(&1, :country))
     end
 
     test "delete/1 removes all members too", %{zone: zone} do
       {:ok, _} = StateZone.delete(zone)
-      assert [] = StateZone.members(zone.id)
+      assert [] = StateZone.members(zone)
     end
 
     test "update/3 succeeds with valid state_ids", %{zone: zone, states: states} do
@@ -57,7 +57,7 @@ defmodule Snitch.Data.Model.StateZoneTest do
       old_state_ids = Enum.map(states, &Map.get(&1, :id))
       new_state_ids = Enum.drop(old_state_ids, 1) ++ more_state_ids
       assert {:ok, _} = StateZone.update(zone, %{}, new_state_ids)
-      state_ids = MapSet.new(StateZone.member_ids(zone.id))
+      state_ids = MapSet.new(StateZone.member_ids(zone))
 
       assert new_state_ids
              |> MapSet.new()
@@ -66,17 +66,17 @@ defmodule Snitch.Data.Model.StateZoneTest do
 
     test "update/3 succeeds with no states", %{zone: zone} do
       assert {:ok, _} = StateZone.update(zone, %{}, [])
-      assert [] = StateZone.member_ids(zone.id)
+      assert [] = StateZone.member_ids(zone)
     end
 
     test "update/3 fails with invalid states", %{zone: zone} do
-      old_state_ids = StateZone.member_ids(zone.id)
+      old_state_ids = StateZone.member_ids(zone)
 
       assert {:error, :added, %{errors: errors}, %{zone: updated_zone}} =
                StateZone.update(zone, %{}, [-1])
 
       assert errors == [state_id: {"does not exist", []}]
-      assert old_state_ids == StateZone.member_ids(updated_zone.id)
+      assert old_state_ids == StateZone.member_ids(updated_zone)
     end
   end
 

--- a/apps/snitch_core/test/data/model/zone/zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/zone_test.exs
@@ -1,0 +1,108 @@
+defmodule Snitch.Data.Model.ZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+  import Snitch.ZoneCase
+
+  alias Snitch.Domain.Zone
+  alias Snitch.Data.Model.{StateZone, CountryZone}
+
+  setup :zones
+
+  setup %{zones: [indian, america, apac]} do
+    [us, ind, china, jp] = countries = countries_with_manifest(~w(US IN CH JP))
+
+    [ka, ap, _up, _tokyo, _ny] =
+      states =
+      states_with_manifest([
+        {"KA", "IN-KA", ind},
+        {"AP", "IN-AP", ind},
+        {"UP", "IN-UP", ind},
+        {"13", "JP-13", jp},
+        {"NY", "US-NY", us}
+      ])
+
+    zone_members([
+      {indian, [ka, ap]},
+      {america, [us]},
+      {apac, [ind, china, jp]}
+    ])
+
+    [
+      countries: countries,
+      states: states,
+      indian: StateZone.fetch_members(indian),
+      america: CountryZone.fetch_members(america),
+      apac: CountryZone.fetch_members(apac)
+    ]
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "KA and AP get apac and south-india zone", context do
+    %{indian: _indian, apac: _apac, countries: [_, ind, _, _], states: [ka, ap, _, _, _]} =
+      context
+
+    ka_address = insert(:address, state: ka, country: ind)
+    ap_address = insert(:address, state: ap, country: ind)
+
+    {state, country} = Zone.common(ka_address, ap_address)
+    assert [_indian] = state
+    assert [_apac] = country
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "KA and UP get apac zone only", context do
+    %{apac: _apac, countries: [_, ind, _, _], states: [ka, _, up, _, _]} = context
+    ka_address = insert(:address, state: ka, country: ind)
+    up_address = insert(:address, state: up, country: ind)
+
+    {state, country} = Zone.common(ka_address, up_address)
+    assert [] = state
+    assert [_apac] = country
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "KA and Tokyo get apac zone", context do
+    %{apac: _apac, countries: [_, ind, _, jp], states: [ka, _, _, tokyo, _]} = context
+    ka_address = insert(:address, state: ka, country: ind)
+    tokyo_address = insert(:address, state: tokyo, country: jp)
+
+    {state, country} = Zone.common(ka_address, tokyo_address)
+    assert [] = state
+    assert [_apac] = country
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "KA and NY get no zone", context do
+    %{countries: [us, ind, _, _], states: [ka, _, _, _, ny]} = context
+    ka_address = insert(:address, state: ka, country: ind)
+    ny_address = insert(:address, state: ny, country: us)
+
+    {state, country} = Zone.common(ka_address, ny_address)
+    assert [] = state
+    assert [] = country
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "JP and CH get apac zone (even without state)", context do
+    %{apac: _apac, countries: [_, _, ch, jp]} = context
+    ch_address = insert(:address, state: nil, country: ch)
+    jp_address = insert(:address, state: nil, country: jp)
+
+    {state, country} = Zone.common(ch_address, jp_address)
+    assert [] = state
+    assert [_apac] = country
+  end
+
+  @tag country_zone_count: 2, state_zone_count: 1
+  test "JP and UP get apac zone (even without JP state)", context do
+    %{apac: _apac, countries: [_, ind, _, jp], states: [_, _, up, _, _]} = context
+    up_address = insert(:address, state: up, country: ind)
+    jp_address = insert(:address, state: nil, country: jp)
+
+    {state, country} = Zone.common(up_address, jp_address)
+    assert [] = state
+    assert [_apac] = country
+  end
+end

--- a/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
@@ -31,5 +31,18 @@ defmodule Snitch.Data.Schema.CountryZoneMemberTest do
       assert {:error, %Ecto.Changeset{errors: errors}} = Repo.insert(new_country_zone)
       assert errors == [zone_id: {"does not refer a country zone", []}]
     end
+
+    test "don't allow duplicate countries in a given zone", %{countries: [country]} do
+      country_zone = insert(:zone, zone_type: "C")
+
+      czm_changset =
+        CountryZoneMember.create_changeset(%CountryZoneMember{country_id: country.id}, %{
+          zone_id: country_zone.id
+        })
+
+      assert {:ok, _} = Repo.insert(czm_changset)
+      assert {:error, cs} = Repo.insert(czm_changset)
+      assert %{country_id: ["has already been taken"]} = errors_on(cs)
+    end
   end
 end

--- a/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
@@ -31,5 +31,18 @@ defmodule Snitch.Data.Schema.StateZoneMemberTest do
       assert {:error, %Ecto.Changeset{errors: errors}} = Repo.insert(new_state_zone)
       assert errors == [zone_id: {"does not refer a state zone", []}]
     end
+
+    test "don't allow duplicate states in a given zone", %{states: [state]} do
+      state_zone = insert(:zone, zone_type: "S")
+
+      szm_changset =
+        StateZoneMember.create_changeset(%StateZoneMember{state_id: state.id}, %{
+          zone_id: state_zone.id
+        })
+
+      assert {:ok, _} = Repo.insert(szm_changset)
+      assert {:error, cs} = Repo.insert(szm_changset)
+      assert %{state_id: ["has already been taken"]} = errors_on(cs)
+    end
   end
 end

--- a/apps/snitch_core/test/support/zone_case.ex
+++ b/apps/snitch_core/test/support/zone_case.ex
@@ -1,0 +1,105 @@
+defmodule Snitch.ZoneCase do
+  @moduledoc """
+  Test helpers to insert zones and zone members.
+
+  ## Sample manifests
+  ```
+  stock_item_sample_manifest = %{
+    "default" => [
+      %{count_on_hand: 3, backorderable: true},
+      %{count_on_hand: 3, backorderable: true},
+      %{count_on_hand: 3, backorderable: true}
+    ],
+    "backup" => [
+      %{count_on_hand: 0},
+      %{count_on_hand: 0},
+      %{count_on_hand: 6}
+    ],
+    "origin" => [ # this is the `admin_name` of the `stock_location`
+      %{count_on_hand: 3},
+      %{count_on_hand: 3},
+      %{count_on_hand: 3}
+    ]
+  }
+  """
+
+  alias Snitch.Repo
+  alias Snitch.Data.Schema.{Country, State, StateZoneMember, CountryZoneMember}
+
+  @state %{
+    name: nil,
+    code: nil,
+    country_id: nil,
+    inserted_at: Ecto.DateTime.utc(),
+    updated_at: Ecto.DateTime.utc()
+  }
+
+  @country %{
+    iso_name: nil,
+    iso: nil,
+    iso3: nil,
+    name: nil,
+    numcode: nil,
+    inserted_at: Ecto.DateTime.utc(),
+    updated_at: Ecto.DateTime.utc()
+  }
+
+  @state_zone_member %{
+    state_id: nil,
+    zone_id: nil,
+    inserted_at: Ecto.DateTime.utc(),
+    updated_at: Ecto.DateTime.utc()
+  }
+
+  @country_zone_member %{
+    country_id: nil,
+    zone_id: nil,
+    inserted_at: Ecto.DateTime.utc(),
+    updated_at: Ecto.DateTime.utc()
+  }
+
+  def countries_with_manifest(manifest) do
+    cs =
+      Enum.map(manifest, fn iso ->
+        %{@country | iso: iso, iso3: iso <> "_", name: iso, numcode: iso}
+      end)
+
+    {_, countries} = Repo.insert_all(Country, cs, returning: true)
+    countries
+  end
+
+  def states_with_manifest(manifest) do
+    ss =
+      Enum.map(manifest, fn {name, code, country} ->
+        %{@state | country_id: country.id, name: name, code: code}
+      end)
+
+    {_, states} = Repo.insert_all(State, ss, returning: true)
+    states
+  end
+
+  def zone_members(manifest) do
+    zm =
+      manifest
+      |> Enum.map(fn
+        {%{zone_type: "S"} = zone, states} ->
+          Enum.map(states, fn state ->
+            %{@state_zone_member | zone_id: zone.id, state_id: state.id}
+          end)
+
+        {%{zone_type: "C"} = zone, countries} ->
+          Enum.map(countries, fn country ->
+            %{@country_zone_member | zone_id: zone.id, country_id: country.id}
+          end)
+      end)
+      |> List.flatten()
+
+    szm = Enum.filter(zm, fn member -> Map.has_key?(member, :state_id) end)
+    czm = Enum.filter(zm, fn member -> Map.has_key?(member, :country_id) end)
+
+    {_, state_members} = Repo.insert_all(StateZoneMember, szm, returning: true)
+    {_, country_members} = Repo.insert_all(CountryZoneMember, czm, returning: true)
+
+    {state_members, country_members}
+  end
+end


### PR DESCRIPTION
## Changes to Zone `Model`s
* Added `fetch_members/1` and updated specs
* Added virtual key `members` to `Zone`

## New `Zone` domain!
* Added the queries to resp. `Model`s
* [Pivotal story](https://www.pivotaltracker.com/story/show/157429785)
(unlike the last commit message, there's no association between `State`, `Country` with `*ZoneMember`, use [`Ecto.assoc/2`](https://hexdocs.pm/ecto/Ecto.html#assoc/2) pls)