### PR TITLE
Mock ShippingMethod cost estimation

### DIFF
--- a/apps/snitch_core/lib/core/data/model/country.ex
+++ b/apps/snitch_core/lib/core/data/model/country.ex
@@ -12,6 +12,6 @@ defmodule Snitch.Data.Model.Country do
     QH.get(Country, query_fields_or_primary_key, Repo)
   end
 
-  @spec formatted_list() :: [{}]
-  def formatted_list(), do: Repo.all(from(s in Country, select: {s.name, s.id}))
+  @spec formatted_list() :: [{String.t(), non_neg_integer}]
+  def formatted_list, do: Repo.all(from(c in Country, select: {c.name, c.id}))
 end

--- a/apps/snitch_core/lib/core/data/model/state.ex
+++ b/apps/snitch_core/lib/core/data/model/state.ex
@@ -12,6 +12,6 @@ defmodule Snitch.Data.Model.State do
     QH.get(State, query_fields_or_primary_key, Repo)
   end
 
-  @spec formatted_list() :: [{}]
-  def formatted_list(), do: Repo.all(from(s in State, select: {s.name, s.id}))
+  @spec formatted_list() :: [{String.t(), non_neg_integer}]
+  def formatted_list, do: Repo.all(from(s in State, select: {s.name, s.id}))
 end

--- a/apps/snitch_core/lib/core/domain/shipping_method.ex
+++ b/apps/snitch_core/lib/core/domain/shipping_method.ex
@@ -4,9 +4,9 @@ defmodule Snitch.Domain.ShippingMethod do
   """
 
   use Snitch.Domain
-  alias Snitch.Data.Model.{ShippingMethod}
+  alias Snitch.Data.Model.ShippingMethod
   alias Snitch.Data.Schema.ShippingMethod, as: SMSchema
-  alias Snitch.Data.Schema.ShippingCategory
+  alias Snitch.Data.Schema.{ShippingCategory, Order}
 
   @doc """
   Returns the `ShippingMethod.t` structs that are applicable for the given
@@ -22,5 +22,13 @@ defmodule Snitch.Domain.ShippingMethod do
   def for_package(zones, %ShippingCategory{} = category)
       when is_list(zones) do
     Repo.all(ShippingMethod.for_package_query(zones, category))
+  end
+
+  @doc """
+  Returns the shipping cost
+  """
+  @spec cost(ShippingMethod.t(), Order.t()) :: Money.t()
+  def cost(%SMSchema{} = _shipping_method, %Order{} = _order) do
+    Money.new(0, :USD)
   end
 end

--- a/apps/snitch_core/test/domain/shipment_test.exs
+++ b/apps/snitch_core/test/domain/shipment_test.exs
@@ -124,7 +124,6 @@ defmodule Snitch.Domain.ShipmentTest do
     # default does not have enough, but is backorderable
     # backup  has none
     # origin  does not have enough
-
     address = %Address{state_id: up.id, country_id: india.id}
     line_items = line_items_with_price(vs, [4])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
@@ -170,7 +169,6 @@ defmodule Snitch.Domain.ShipmentTest do
     # default has none
     # backup  has none
     # origin  has none
-
     address = %Address{state_id: up.id, country_id: india.id}
     line_items = line_items_with_price(vs, [0, 2])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
@@ -196,7 +194,6 @@ defmodule Snitch.Domain.ShipmentTest do
     # default does not have enough, but is backorderable
     # backup  has enough
     # origin  does not have enough
-
     address = %Address{state_id: tn.id, country_id: india.id}
     line_items = line_items_with_price(vs, [0, 0, 6])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
@@ -255,13 +252,6 @@ defmodule Snitch.Domain.ShipmentTest do
 
   @tag variant_count: 3, state_zone_count: 2
   test "package from default gets split (shipping_category)", context do
-    # Line items:
-    # + 4 pieces of variant_1
-    # + 4 pieces of variant_3
-    #
-    # default does not have enough, but is backorderable (for both variants)
-    # backup  has enough of variant_3, none of variant_1
-    # origin  does not have enough
     %{
       variants: [%{id: one_id}, _, %{id: three_id}] = vs,
       stock_locations: stock_locations,
@@ -271,6 +261,13 @@ defmodule Snitch.Domain.ShipmentTest do
       shipping_categories: [light, heavy, _]
     } = context
 
+    # Line items:
+    # + 4 pieces of variant_1
+    # + 4 pieces of variant_3
+    #
+    # default does not have enough, but is backorderable (for both variants)
+    # backup  has enough of variant_3, none of variant_1
+    # origin  does not have enough
     address = %Address{state_id: mh.id, country_id: india.id}
     line_items = line_items_with_price(vs, [4, 0, 4])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
@@ -373,9 +370,7 @@ defmodule Snitch.Domain.ShipmentTest do
     # default has enough
     # backup  has none
     # origin  has enough
-
     address = %Address{state_id: ka.id, country_id: india.id}
-
     line_items = line_items_with_price(vs, [3])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
     packages = Shipment.default_packages(order)

--- a/apps/snitch_core/test/support/shipment_case.ex
+++ b/apps/snitch_core/test/support/shipment_case.ex
@@ -13,14 +13,6 @@ defmodule Snitch.ShipmentCase do
     updated_at: Ecto.DateTime.utc()
   }
 
-  @shipping_method %{
-    name: nil,
-    slug: nil,
-    description: nil,
-    inserted_at: Ecto.DateTime.utc(),
-    updated_at: Ecto.DateTime.utc()
-  }
-
   @doc """
   Creates `ShippingCategory`s according to the manifest.
 


### PR DESCRIPTION
## Motivation
Pivotal story: [#156081076](https://www.pivotaltracker.com/story/show/156081076)
The `Estimator` has to compute the `shipping_cost`, and possibly other totals for each package.

## Description
1. `Domain.ShippingMethod.cost/2`
    This estimates the cost for the given shipping method and order. It always returns $0, as we don't have Calculators yet (hence the name `Mock...`).

## Gotchas!
The calculator might require not only the order but also _this_ package. For ex, the chosen `ShippingMethod` might compute different costs depending on the package's weight, volume or dimensions.

Since a package can be split, we have to update the estimate _after_ all packages of the (optimal) shipment are available.

------
## Checklist
- [x] I have read the [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo
