### PR TITLE
Add PR and git commit templates

### DIFF
--- a/.git_commit_msg.txt
+++ b/.git_commit_msg.txt
@@ -1,0 +1,33 @@
+# If applied, this commit will...
+
+
+# this bar is where 50 columns is at    --------->|                                                 
+# Complete the sentence above,
+# +  Capitalize it!
+# +  Don't end with a period (full-stop)!
+#
+# Commit description, use maximum 72 chars
+#
+# Why is this change needed?
+Prior to this change, 
+
+
+# this bar is where 72 columns is at       ---------------------------->|
+#
+# How does it address the issue?
+This change
+
+
+# this bar is where 72 columns is at       ---------------------------->|
+#
+# Provide links to any relevant tickets, articles or other resources
+
+
+# this bar is where 72 columns is at       ---------------------------->|
+#
+# For more details on how to write a good commit message please visit:
+# https://chris.beams.io/posts/git-commit/
+#
+# Thank you for taking the time to write a good commit message!
+# We highly appreciate it!
+# Take a hug! (づ｡◕‿‿◕｡)づ

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
+
+## Describe your changes
+<!--- List and detail all changes made in this PR. -->
+
+## Any further comments?
+
+<!-- If this is a relatively large or complex change, kick off the discussion by -->
+<!-- explaining why you chose the solution you did and what alternatives you -->
+<!-- considered, etc... -->
+
+------
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have read [CONTRIBUTING.md][contributing].
+- [ ] My code follows the [style guidelines][contributing] of this project.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
+- [ ] I have updated the documentation wherever necessary.
+- [ ] I have added tests to cover my changes.
+
+[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
+[credo]: https://github.com/rrrene/credo
+
+<!--- DO NOT REMOVE SECTION BELOW -->
+------
+Dear Gatekeeper,
+
+Please make sure that the commits that will be merged or rebased into the base
+branch are [formatted according to our standards](commit-template).
+
+> The only additional requirement is that the the PR number must appear in the
+> commit title in brackets: `(#XXX)`
+
+[commit-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,14 @@ The repo includes some handy `git` hooks under `.scripts/`:
 
 We strongly recommend that you set up these git hooks on your machine by:
 ```sh
-# in the project root!
+# sh
+# in the project root, run:
 ln -sf ../../.scripts/pre-commit .git/hooks/pre-commit
 ln -sf ../../.scripts/post-commit .git/hooks/post-commit
 ```
 
-> Note that our CI will fail your PR if you dont run `mix format` in the project
-> root.
+> **Note that our CI will fail your PR if you dont run `mix format` in the project
+> root.**
 
 ## Styling
 
@@ -24,8 +25,23 @@ We follow
 [rrrene/elixir-style-guide](https://github.com/rrrene/elixir-style-guide) (both
 overlap a lot).
 
-## PR submission checklist
+Our commit messages (at least on [`develop`][dev]) are [formatted as described
+here][commit-format].
 
-* [ ] `git` hooks had been set up before development.
-* [ ] You ran `mix dialyzer` and no new warnings were emitted (especially due to
-      your changes).
+Please set up [our super nice commit message template][our-template] to
+supercharge :zap::zap: your commit messages!
+
+```sh
+# sh
+# in the project root, run:
+
+git config commit.template .git_commit_msg.txt
+```
+
+To make this your commit template globally, just add the `--global` flag!
+
+Have fun commiting new changes! :rainbow:
+
+[dev]: https://github.com/aviabird/snitch/tree/develop
+[commit-format]: https://chris.beams.io/posts/git-commit/
+[our-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt


### PR DESCRIPTION
## Motivation
* Incomplete PR descriptions and Pivotal stories cause confusion, friction, and loss of valuable information.
* Even more friction is caused when commit messages are lame. [LEARN HOW TO WRITE BETTER ONES](https://chris.beams.io/posts/git-commit/).
  - At least the squash/merge commits on `develop` should have this standard.
  - The PR should not be merged unless the squashed commit message is perfected.

## Description
This PR is a sample of how things would look.
Like it? Hate it? Please comment! :angel:

Also added a git commit template. **If you are not already using our `git-hooks`, its high time you set them up.**
Check the contributing guide. **If there's a mistake in it comment on this PR that it does not work.**

And while you're at it, also add this commit template to your git config:
```sh
# in the project root:
git config commit.template .git_commit_msg.txt
```
:peace_symbol: 