### PR TITLE
Add address-to-payment in checkouts controller

### DIFF
--- a/apps/api/lib/api_web/controllers/checkout_controller.ex
+++ b/apps/api/lib/api_web/controllers/checkout_controller.ex
@@ -23,6 +23,10 @@ defmodule ApiWeb.CheckoutController do
     json(conn, %{})
   end
 
+  def do_next(conn, %{state: "payment"}) do
+    json(conn, %{})
+  end
+
   def add_addresses(conn, %{"order_id" => order_id, "order" => addresses}) do
     id =
       order_id

--- a/apps/api/lib/api_web/controllers/order_controller.ex
+++ b/apps/api/lib/api_web/controllers/order_controller.ex
@@ -8,7 +8,7 @@ defmodule ApiWeb.OrderController do
   import Ecto.Query
 
   def current(conn, _params) do
-    query = from(c in OrderSchema, order_by: c.id)
+    query = from(o in OrderSchema, order_by: o.id)
 
     order =
       query

--- a/apps/api/lib/api_web/controllers/payment_controller.ex
+++ b/apps/api/lib/api_web/controllers/payment_controller.ex
@@ -4,10 +4,46 @@ defmodule ApiWeb.PaymentController do
   import Ecto.Query, only: [from: 2]
 
   alias Snitch.Repo
+  alias BeepBop.Context
+  alias Snitch.Domain.Order.DefaultMachine
   alias Snitch.Data.Schema.PaymentMethod
+  alias Snitch.Data.Model.Order
+  alias Snitch.Data.Model.PaymentMethod, as: PaymentMethodModel
+  alias ApiWeb.FallbackController, as: Fallback
 
   def new(conn, _params) do
     payment_methods = Repo.all(from(pm in PaymentMethod, where: pm.active? == true))
     render(conn, "payment_methods.json", payment_methods: payment_methods)
+  end
+
+  def create(conn, %{"payment" => payment_params, "order_id" => id}) do
+    %{
+      "payment_method_id" => pm_id,
+      "amount" => amount
+    } = payment_params
+
+    order = Order.get(%{id: id})
+    payment_method = PaymentMethodModel.get(%{id: pm_id})
+
+    params = %{
+      amount: Money.from_float(amount, order.total.currency)
+    }
+
+    context =
+      order
+      |> Repo.preload(:line_items)
+      |> Context.new(state: %{payment_params: params, card_params: nil})
+      |> DefaultMachine.add_payment()
+
+    case context do
+      %{valid?: true, multi: %{payment: payment, persist: order}} ->
+        render(conn, "payment.json", payment: payment)
+
+      %{valid?: false, multi: errors} ->
+        Fallback.call(conn, errors)
+
+      {:error, error} ->
+        Fallback.call(conn, {:error, error})
+    end
   end
 end

--- a/apps/api/lib/api_web/controllers/product_controller.ex
+++ b/apps/api/lib/api_web/controllers/product_controller.ex
@@ -14,7 +14,7 @@ defmodule ApiWeb.ProductController do
 
   def show(conn, params) do
     product =
-      Repo.get_by(Product, slug: params["product_slug"])
+      Repo.get_by(Product, slug: params["id"])
       |> Repo.preload(variants: [:images])
 
     render(conn, "product.json", product: product)

--- a/apps/api/lib/api_web/controllers/product_controller.ex
+++ b/apps/api/lib/api_web/controllers/product_controller.ex
@@ -12,7 +12,7 @@ defmodule ApiWeb.ProductController do
     render(conn, "products.json", products: products)
   end
 
-  def product(conn, params) do
+  def show(conn, params) do
     product =
       Repo.get_by(Product, slug: params["product_slug"])
       |> Repo.preload(variants: [:images])

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -19,8 +19,7 @@ defmodule ApiWeb.Router do
       resources("/payments", PaymentController, only: [:new])
     end
 
-    get("/products", ProductController, :index)
-    get("/products/:product_slug", ProductController, :product)
+    resources("/products", ProductController, only: [:index, :show])
 
     scope("/checkouts") do
       put("/:order_id/next.json", CheckoutController, :next)

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -16,7 +16,7 @@ defmodule ApiWeb.Router do
     end
 
     resources("/orders", OrderController, only: [:create]) do
-      resources("/payments", PaymentController, only: [:new])
+      resources("/payments", PaymentController, only: [:new, :create])
     end
 
     resources("/products", ProductController, only: [:index, :show])

--- a/apps/api/lib/api_web/views/payment_view.ex
+++ b/apps/api/lib/api_web/views/payment_view.ex
@@ -1,6 +1,17 @@
 defmodule ApiWeb.PaymentView do
   use ApiWeb, :view
 
+  def render("payment.json", %{payment: payment}) do
+    payment
+    |> Map.from_struct()
+    |> Map.drop(~w[__meta__ order payment_method]a)
+    |> Map.merge(%{
+      amount: payment.amount,
+      display_amount: Money.to_string!(payment.amount),
+      number: payment.slug
+    })
+  end
+
   def render("payment_methods.json", %{payment_methods: payments}) do
     %{
       payment_methods: render_many(payments, __MODULE__, "payment_method.json"),

--- a/apps/snitch_core/lib/core/data/model/payment/card_payment.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/card_payment.ex
@@ -21,11 +21,11 @@ defmodule Snitch.Data.Model.CardPayment do
   represented by `order_id`.
 
   * `payment_params` are validated using
-    `Snitch.Data.Schema.Payment.changeset/3` with the `:create` action and
-    because `slug` and `order_id` are passed explicitly to this function,
-    they'll be ignored if present in `payment_params`.
+    `Snitch.Data.Schema.Payment.create_changeset/3` and because `slug` and
+    `order_id` are passed explicitly to this function, they'll be ignored if
+    present in `payment_params`.
   * `card_params` are validated using
-  `Snitch.Data.Schema.CardPayment.changeset/3` with the `:create` action.
+  `Snitch.Data.Schema.CardPayment.create_changeset/3`.
   """
   @spec create(String.t(), non_neg_integer(), map, map) ::
           {:ok, %{card_payment: CardPayment.t(), payment: Payment.t()}}
@@ -58,10 +58,8 @@ defmodule Snitch.Data.Model.CardPayment do
   Everything except the `:payment_type` and `amount` can be changed, because by
   changing the type, `CardPayment` will have to be deleted.
 
-  * `card_params` are validated using `CardPayment.changeset/3` with the
-    `:update` action.
-  * `payment_params` are validated using `Schema.Payment.changeset/3` with the
-    `:update` action.
+  * `card_params` are validated using `CardPayment.update_changeset/3`.
+  * `payment_params` are validated using `Schema.Payment.update_changeset/3`
   """
   @spec update(CardPayment.t(), map, map) ::
           {:ok, %{card_payment: CardPayment.t(), payment: Payment.t()}}
@@ -78,7 +76,7 @@ defmodule Snitch.Data.Model.CardPayment do
   end
 
   @doc """
-  Fetches the struct but does not preload `:payment` association.
+  Fetches the `CardPayment` struct but does not preload `:payment` association.
   """
   @spec get(map | non_neg_integer) :: CardPayment.t() | nil
   def get(query_fields_or_primary_key) do

--- a/apps/snitch_core/lib/core/data/model/payment/check_payment.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/check_payment.ex
@@ -1,0 +1,70 @@
+defmodule Snitch.Data.Model.CheckPayment do
+  @moduledoc """
+  CheckPayment API and utilities.
+
+  `CheckPayment` is a concrete payment subtype in Snitch. By `create/4`ing a
+  CheckPayment, the supertype Payment is automatically created in the same
+  transaction.
+
+  > For other supported payment sources, see
+    `Snitch.Data.Schema.PaymentMethod`
+  """
+  use Snitch.Data.Model
+
+  alias Snitch.Data.Schema.Payment
+  alias Snitch.Data.Model.Payment, as: PaymentModel
+  alias Snitch.Data.Model.PaymentMethod, as: PaymentMethodModel
+  alias Ecto.Multi
+
+  @doc """
+  Creates the a "check" `Payment` for Order represented by `order_id`.
+
+  * `payment_params` are validated using
+    `Snitch.Data.Schema.Payment.create_changeset/3`.
+  """
+  @spec create(map) :: {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
+  def create(params) do
+    check_method = PaymentMethodModel.get_check()
+
+    params =
+      params
+      |> Map.put(:payment_type, "chk")
+      |> Map.put(:payment_method_id, check_method.id)
+
+    %Payment{}
+    |> Payment.create_changeset(params)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates the `check_payment`.
+
+  Everything except the `:payment_type` and `amount` can be changed, because by
+  changing the type, `CheckPayment` will have to be deleted.
+
+  * `params` are validated using `Schema.Payment.update_changeset/3`
+  """
+  @spec update(Payment.t(), map) :: {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
+  def update(check_payment, params) do
+    PaymentModel.update(check_payment, params)
+  end
+
+  @doc """
+  Fetches the `Payment` struct.
+  """
+  @spec get(map | non_neg_integer) :: Payment.t() | nil
+  def get(query_fields_or_primary_key) do
+    QH.get(Payment, query_fields_or_primary_key, Repo)
+  end
+
+  @spec get_all() :: [Payment.t()]
+  def get_all, do: Repo.all(from(p in Payment, where: p.payment_type == "chk"))
+
+  @doc """
+  Fetch the CheckPayment identified by the `payment_id`.
+  """
+  @spec from_payment(non_neg_integer) :: Payment.t()
+  def from_payment(payment_id) do
+    get(%{id: payment_id, payment_type: "chk"})
+  end
+end

--- a/apps/snitch_core/lib/core/domain/order/default_machine.ex
+++ b/apps/snitch_core/lib/core/domain/order/default_machine.ex
@@ -65,9 +65,7 @@ defmodule Snitch.Domain.Order.DefaultMachine do
       |> Transitions.persist_shipment()
     end)
 
-    event(:add_payment, %{from: [:address], to: :payment}, fn context ->
-      context
-    end)
+    event(:add_payment, %{from: [:address], to: :payment}, &Transitions.associate_payment/1)
 
     event(:confirm, %{from: [:payment], to: :processing}, fn context ->
       context


### PR DESCRIPTION
## Motivation
Pivotal story: [#157751042](https://www.pivotaltracker.com/story/show/157751042)
Allows an order to be paid for via the "check" payment method.

## Description
* New `CheckPayment` model. Makes it simpler to create a check payment.
* Implements the `add_payment` event transition in the `Order.DefaultMachine`
  - supports `CheckPayment` exclusively!