### PR TITLE
Add fix for Current Order

### DIFF
--- a/apps/api/lib/api_web/controllers/line_item_controller.ex
+++ b/apps/api/lib/api_web/controllers/line_item_controller.ex
@@ -1,0 +1,85 @@
+defmodule ApiWeb.LineItemController do
+  use ApiWeb, :controller
+
+  alias Snitch.Repo
+  alias Snitch.Data.Model.Order
+  alias ApiWeb.FallbackController, as: Fallback
+
+  def create(conn, params) do
+    order_id = Map.fetch!(params, "order_id")
+    variant_id = Map.fetch!(params["line_item"], "variant_id")
+    quantity = Map.fetch!(params["line_item"], "quantity")
+
+    with {:ok, order} <- load_order(order_id) do
+      variants = order_variants_list(order.line_items)
+      items = items_to_insert(order, variants, variant_id, quantity)
+
+      case Order.update(%{line_items: items}, order) do
+        {:ok, order} ->
+          added_item(conn, order, variant_id)
+
+        {:error, _} = error ->
+          Fallback.call(conn, error)
+      end
+    else
+      :error -> Fallback.call(conn, {:error, :not_found})
+    end
+  end
+
+  def load_order(order_id) do
+    order_id
+    |> String.to_integer()
+    |> Order.get()
+    |> case do
+      nil ->
+        :error
+
+      order ->
+        {:ok,
+         Repo.preload(
+           order,
+           line_items: [variant: :images],
+           shipping_address: [],
+           billing_address: []
+         )}
+    end
+  end
+
+  defp items_to_insert(order, variants, variant_id, quantity) do
+    case MapSet.member?(variants, variant_id) do
+      true ->
+        line_items_manifest(order.line_items, variant_id, quantity)
+
+      false ->
+        old_items = line_items_manifest(order.line_items, variant_id, quantity)
+        [%{variant_id: variant_id, quantity: quantity} | old_items]
+    end
+  end
+
+  defp line_items_manifest(line_items, variant_id, quantity) do
+    Enum.reduce(line_items, [], fn line_item, acc ->
+      if line_item.variant_id == variant_id do
+        [%{id: line_item.id, quantity: line_item.quantity + quantity} | acc]
+      else
+        [%{id: line_item.id} | acc]
+      end
+    end)
+  end
+
+  defp order_variants_list(line_items) do
+    Enum.reduce(line_items, MapSet.new(), fn %{variant_id: id}, acc ->
+      MapSet.put(acc, id)
+    end)
+  end
+
+  defp added_item(conn, order, variant_id) do
+    item =
+      order.line_items
+      |> Enum.find(fn line_item ->
+        line_item.variant_id == variant_id
+      end)
+      |> Repo.preload(variant: :images)
+
+    render(conn, "line_item.json", line_item: item)
+  end
+end

--- a/apps/api/lib/api_web/controllers/order_controller.ex
+++ b/apps/api/lib/api_web/controllers/order_controller.ex
@@ -5,12 +5,12 @@ defmodule ApiWeb.OrderController do
   alias Snitch.Repo
   alias ApiWeb.FallbackController, as: Fallback
 
-  def current(conn, params) do
-    order_id = String.to_integer(Map.fetch!(params, "id"))
+  def show(conn, %{"id" => id}) do
+    order_id = String.to_integer(id)
 
     case Order.get(order_id) do
       nil ->
-        do_create(conn, params, [])
+        Fallback.call(conn, {:error, :not_found})
 
       order ->
         render_order(conn, order)
@@ -60,83 +60,5 @@ defmodule ApiWeb.OrderController do
 
   defp unique_id do
     UUID.uuid1()
-  end
-
-  def add_line_item(conn, params) do
-    order_id = Map.fetch!(params, "order_number")
-    variant_id = Map.fetch!(params["line_item"], "variant_id")
-    quantity = Map.fetch!(params["line_item"], "quantity")
-
-    with {:ok, order} <- load_order(order_id) do
-      variants = order_variants_list(order.line_items)
-      items = items_to_insert(order, variants, variant_id, quantity)
-
-      case Order.update(%{line_items: items}, order) do
-        {:ok, order} ->
-          added_item(conn, order, variant_id)
-
-        {:error, _} = error ->
-          Fallback.call(conn, error)
-      end
-    else
-      :error -> Fallback.call(conn, {:error, :not_found})
-    end
-  end
-
-  def load_order(order_id) do
-    order_id
-    |> String.to_integer()
-    |> Order.get()
-    |> case do
-      nil ->
-        :error
-
-      order ->
-        {:ok,
-         Repo.preload(
-           order,
-           line_items: [variant: :images],
-           shipping_address: [],
-           billing_address: []
-         )}
-    end
-  end
-
-  defp items_to_insert(order, variants, variant_id, quantity) do
-    case MapSet.member?(variants, variant_id) do
-      true ->
-        line_items_manifest(order.line_items, variant_id, quantity)
-
-      false ->
-        old_items = line_items_manifest(order.line_items, variant_id, quantity)
-        [%{variant_id: variant_id, quantity: quantity} | old_items]
-    end
-  end
-
-  defp line_items_manifest(line_items, variant_id, quantity) do
-    Enum.reduce(line_items, [], fn line_item, acc ->
-      if line_item.variant_id == variant_id do
-        [%{id: line_item.id, quantity: line_item.quantity + quantity} | acc]
-      else
-        [%{id: line_item.id} | acc]
-      end
-    end)
-  end
-
-  defp order_variants_list(line_items) do
-    Enum.reduce(line_items, MapSet.new(), fn %{variant_id: id}, acc ->
-      MapSet.put(acc, id)
-    end)
-  end
-
-  defp added_item(conn, order, variant_id) do
-    item =
-      order.line_items
-      |> Enum.find(fn line_item ->
-        line_item.variant_id == variant_id
-      end)
-      |> Repo.preload(variant: :images)
-
-    render(conn, "lineitem.json", line_item: item)
   end
 end

--- a/apps/api/lib/api_web/controllers/payment_controller.ex
+++ b/apps/api/lib/api_web/controllers/payment_controller.ex
@@ -8,7 +8,6 @@ defmodule ApiWeb.PaymentController do
   alias Snitch.Domain.Order.DefaultMachine
   alias Snitch.Data.Schema.PaymentMethod
   alias Snitch.Data.Model.Order
-  alias Snitch.Data.Model.PaymentMethod, as: PaymentMethodModel
   alias ApiWeb.FallbackController, as: Fallback
 
   def new(conn, _params) do
@@ -18,12 +17,11 @@ defmodule ApiWeb.PaymentController do
 
   def create(conn, %{"payment" => payment_params, "order_id" => id}) do
     %{
-      "payment_method_id" => pm_id,
+      "payment_method_id" => _pm_id,
       "amount" => amount
     } = payment_params
 
     order = Order.get(%{id: id})
-    payment_method = PaymentMethodModel.get(%{id: pm_id})
 
     params = %{
       amount: Money.from_float(amount, order.total.currency)
@@ -36,7 +34,7 @@ defmodule ApiWeb.PaymentController do
       |> DefaultMachine.add_payment()
 
     case context do
-      %{valid?: true, multi: %{payment: payment, persist: order}} ->
+      %{valid?: true, multi: %{payment: payment}} ->
         render(conn, "payment.json", payment: payment)
 
       %{valid?: false, multi: errors} ->

--- a/apps/api/lib/api_web/controllers/product_controller.ex
+++ b/apps/api/lib/api_web/controllers/product_controller.ex
@@ -4,7 +4,7 @@ defmodule ApiWeb.ProductController do
   alias Snitch.Data.Schema.Product
   alias Snitch.Repo
 
-  def index(conn, params) do
+  def index(conn, _params) do
     products =
       Repo.all(Product)
       |> Repo.preload(variants: [:images])

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -10,16 +10,11 @@ defmodule ApiWeb.Router do
 
     get("/taxonomies", TaxonomyController, :index)
 
-    post("orders.json", OrderController, :create)
+    post("/orders.json", OrderController, :create)
 
-    scope("/orders") do
-      get("/current/:id", OrderController, :current)
-      get("/:order_number/payments/new", PaymentController, :payment_methods)
-      post("/:order_number/line_items/", OrderController, :add_line_item)
-    end
-
-    resources("/orders", OrderController, only: [:create]) do
+    resources("/orders", OrderController, only: [:show]) do
       resources("/payments", PaymentController, only: [:new, :create])
+      resources("/line_items", LineItemController, only: [:create])
     end
 
     resources("/products", ProductController, only: [:index, :show])

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -10,8 +10,11 @@ defmodule ApiWeb.Router do
 
     get("/taxonomies", TaxonomyController, :index)
 
+    post("orders.json", OrderController, :create)
+
     scope("/orders") do
-      get("/current", OrderController, :current)
+      get("/current/:id", OrderController, :current)
+      get("/:order_number/payments/new", PaymentController, :payment_methods)
       post("/:order_number/line_items/", OrderController, :add_line_item)
     end
 

--- a/apps/api/lib/api_web/views/line_item_view.ex
+++ b/apps/api/lib/api_web/views/line_item_view.ex
@@ -1,0 +1,40 @@
+defmodule ApiWeb.LineItemView do
+  use ApiWeb, :view
+  import ApiWeb.ProductView, only: [image_variant: 1]
+
+  def render("line_item.json", %{line_item: line_item}) do
+    line_item
+    |> Map.from_struct()
+    |> Map.drop(~w[__meta__ order variant]a)
+    |> Map.merge(%{
+      "adjustments" => [],
+      "single_display_amount" => Money.to_string!(line_item.unit_price),
+      "display_amount" => Money.to_string!(line_item.total),
+      "total" => line_item.total.amount,
+      "price" => line_item.unit_price.amount,
+      "variant" => render_variant(line_item.variant)
+    })
+  end
+
+  defp render_variant(variant) do
+    variant
+    |> Map.from_struct()
+    |> Map.drop(~w[__meta__ stock_items shipping_category images product]a)
+    |> Map.merge(%{
+      "name" => variant.sku,
+      "price" => variant.selling_price.amount,
+      "is_master" => true,
+      "slug" => variant.sku,
+      "cost_price" => variant.cost_price.amount,
+      "option_values" => [],
+      "display_price" => Money.to_string!(variant.selling_price),
+      "options_text" => "",
+      "in_stock" => true,
+      "is_backorderable" => true,
+      "is_orderable" => true,
+      "total_on_hand" => 100,
+      "is_destroyed" => false,
+      "images" => Enum.map(variant.images, &image_variant/1)
+    })
+  end
+end

--- a/apps/api/lib/api_web/views/order_view.ex
+++ b/apps/api/lib/api_web/views/order_view.ex
@@ -41,6 +41,10 @@ defmodule ApiWeb.OrderView do
     )
   end
 
+  def render("lineitem.json", %{line_item: line_item}) do
+    render_line_item(line_item)
+  end
+
   def render_order(order) do
     %{
       "number" => order.id,
@@ -50,7 +54,7 @@ defmodule ApiWeb.OrderView do
       "currency" => order.total.currency,
       "display_item_total" => Money.to_string!(order.item_total),
       "total_quantity" =>
-        Enum.reduce(Enum.map(order.line_items, fn %{quantity: q} -> q end), &+/2),
+        Enum.reduce(Enum.map(order.line_items, fn %{quantity: q} -> q end), 0, &+/2),
       "display_total" => Money.to_string!(order.item_total),
       "display_ship_total" => Money.to_string!(Money.zero(:USD)),
       "display_tax_total" => Money.to_string!(Money.zero(:USD)),


### PR DESCRIPTION
Prior to this change,
* The `/api/orders/current` path returned any random
  `order` from the db.

This change
* change `/api/v1/orders/current` -> `/api/v1/orders/current/:id`
* The api now checks if an order exists with the provided `id`
  in the system if yes retuens the same otherwise, creates a
  new empty `order` and returns it.