### PR TITLE
Endpoint to remove line item

### DIFF
--- a/apps/api/lib/api_web/cors.ex
+++ b/apps/api/lib/api_web/cors.ex
@@ -6,7 +6,7 @@ defmodule ApiWeb.CORS do
     log: [rejected: :error],
     allow_credentials: true,
     allow_headers: ["content-type", "token-type"],
-    allow_methods: ["GET", "PUT", "OPTIONS"],
+    allow_methods: ["GET", "PUT", "OPTIONS", "DELETE"],
     max_age: 600
 
   resource("/*")

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -14,7 +14,7 @@ defmodule ApiWeb.Router do
 
     resources("/orders", OrderController, only: [:show]) do
       resources("/payments", PaymentController, only: [:new, :create])
-      resources("/line_items", LineItemController, only: [:create])
+      resources("/line_items", LineItemController, only: [:create, :delete])
     end
 
     resources("/products", ProductController, only: [:index, :show])

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -54,7 +54,7 @@ defmodule Snitch.Data.Model.Order do
 
   ```
   order # this is the order you wish to update, and `:line_items` are preloaded
-  line_items = Enum.reduce(order.line_items, [], fn x, acc -> 
+  line_items = Enum.reduce(order.line_items, [], fn x, acc ->
     [%{id: x.id} | acc]
   end)
   params = %{} # All changes except line-items


### PR DESCRIPTION
Adds API endpoint to remove line item from order

## Motivation and Context
User should be able to remove line item from order.

## Describe your changes

Get the line item from API params and updates the order by removing that line item.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards](commit-template).

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt
