### PR TITLE
Simplify Address changeset

### DIFF
--- a/apps/snitch_core/lib/core/data/schema/address.ex
+++ b/apps/snitch_core/lib/core/data/schema/address.ex
@@ -23,94 +23,119 @@ defmodule Snitch.Data.Schema.Address do
     field(:phone, :string)
     field(:alternate_phone, :string)
 
-    belongs_to(:state, State)
-    belongs_to(:country, Country)
+    belongs_to(:state, State, on_replace: :nilify)
+    belongs_to(:country, Country, on_replace: :nilify)
     timestamps()
   end
 
-  @required_fields ~w(first_name last_name address_line_1 city zip_code)a
-  @optional_fields ~w(phone alternate_phone country_id state_id)a
+  @required_fields ~w(first_name last_name address_line_1 city zip_code country_id)a
+  @cast_fields ~w(phone alternate_phone state_id)a ++ @required_fields
 
   @doc """
-  Returns an `Address` changeset to create a new `address`.
+  Returns an `Address` changeset to create OR update `address`.
 
   An address must be associated with a country, and if the country has
   sub-divisions (aka states) according to ISO 3166-2, then the address must also
   be associated with a state.
 
   ## Note
-  You can provide either the Country and State structs under the `:country` and
-  `:state` keys resp. or just their IDs under `:country_id` and `:state_id`
-
-  If you provide both, the `:country_id` and/or `:state_id` will be ignored.
+  You may only provide `:country_id` and `:state_id`, structs under `:country`
+  and `:state` are ignored.
   """
-  @spec create_changeset(t, map) :: Ecto.Changeset.t()
-  def create_changeset(%__MODULE__{} = address, params) do
-    filtered_params =
-      params
-      |> Stream.reject(fn {_, x} ->
-        is_nil(x)
-      end)
-      |> Enum.into(%{})
-
+  @spec changeset(t, map) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = address, params) do
     address
-    |> cast(filtered_params, @required_fields ++ @optional_fields)
+    |> cast(params, @cast_fields)
     |> validate_required(@required_fields)
     |> validate_length(:address_line_1, min: 10)
     |> assoc_country_and_state()
   end
 
-  defp assoc_country_and_state(changeset) do
-    with :error <- Map.fetch(changeset.params, "country"),
-         {:ok, country_id} <- fetch_change(changeset, :country_id),
-         nil <- Repo.get(Country, country_id) do
-      add_error(changeset, :country_id, "does not exist", country_id: country_id)
-    else
-      {:ok, %Country{} = country} ->
-        changeset
-        |> put_assoc(:country, country)
-        |> assoc_state(country)
-
-      :error ->
-        add_error(changeset, :country, "country or country_id can't be blank")
+  defp assoc_country_and_state(
+         %{
+           valid?: true,
+           changes: %{
+             country_id: c_id,
+             state_id: s_id
+           }
+         } = changeset
+       ) do
+    case Repo.get(Country, c_id) do
+      nil ->
+        add_error(changeset, :country_id, "does not exist", country_id: c_id)
 
       %Country{} = country ->
         changeset
         |> put_assoc(:country, country)
-        |> assoc_state(country)
+        |> assoc_state(country, s_id)
     end
   end
 
-  defp assoc_state(changeset, %{states_required: true} = country) do
-    with :error <- Map.fetch(changeset.params, "state"),
-         {:ok, state_id} <- fetch_change(changeset, :state_id),
-         nil <- Repo.get(State, state_id) do
-      add_error(changeset, :state_id, "does not exist", state_id: state_id)
-    else
-      {:ok, %State{} = state} ->
-        validate_state(changeset, country, state)
+  defp assoc_country_and_state(
+         %{
+           valid?: true,
+           changes: %{state_id: s_id},
+           data: %{country_id: c_id}
+         } = changeset
+       ) do
+    case Repo.get(Country, c_id) do
+      nil ->
+        add_error(changeset, :country_id, "does not exist", country_id: c_id)
 
-      :error ->
-        add_error(changeset, :state, "state is required for this country", country_id: country.id)
+      %Country{} = country ->
+        assoc_state(changeset, country, s_id)
+    end
+  end
+
+  defp assoc_country_and_state(
+         %{
+           valid?: true,
+           changes: %{country_id: c_id}
+         } = changeset
+       ) do
+    case Repo.get(Country, c_id) do
+      nil ->
+        add_error(changeset, :country_id, "does not exist", country_id: c_id)
+
+      %Country{} = country ->
+        changeset
+        |> put_assoc(:country, country)
+        |> assoc_state(country, nil)
+    end
+  end
+
+  defp assoc_country_and_state(changeset), do: changeset
+
+  defp assoc_state(changeset, %Country{states_required: false}, _) do
+    put_change(changeset, :state_id, nil)
+  end
+
+  defp assoc_state(changeset, %{states_required: true} = country, s_id) when is_integer(s_id) do
+    case Repo.get(State, s_id) do
+      nil ->
+        add_error(changeset, :state_id, "does not exist", state_id: s_id)
 
       %State{} = state ->
-        validate_state(changeset, country, state)
+        if state.country_id == country.id do
+          put_assoc(changeset, :state, state)
+        else
+          add_error(
+            changeset,
+            :state,
+            "state does not belong to country",
+            state_id: state.id,
+            country_id: country.id
+          )
+        end
     end
   end
 
-  defp assoc_state(changeset, _), do: changeset
-
-  defp validate_state(changeset, country, state) do
-    if state.country_id == country.id do
-      put_assoc(changeset, :state, state)
-    else
-      add_error(
-        changeset,
-        :state,
-        "state does not belong to country",
-        state_id: state.id,
-        country_id: country.id
-      )
-    end
+  defp assoc_state(changeset, %{states_required: true} = country, _) do
+    add_error(
+      changeset,
+      :state_id,
+      "state is explicitly required for this country",
+      country_id: country.id
+    )
   end
 end

--- a/apps/snitch_core/test/data/schema/address_test.exs
+++ b/apps/snitch_core/test/data/schema/address_test.exs
@@ -4,39 +4,45 @@ defmodule Snitch.Data.Schema.AddressTest do
 
   import Snitch.Factory
 
-  alias Snitch.Data.Schema.{Address, Country}
+  alias Snitch.Data.Schema.Address
 
-  @valid_params %{
+  @params %{
     first_name: "Tony",
     last_name: "Stark",
     address_line_1: "10-8-80 Malibu Point",
     zip_code: "90265",
     city: "Malibu",
-    phone: "1234567890"
+    phone: "1234567890",
+    state: nil,
+    state_id: nil,
+    country: nil,
+    country_id: nil
   }
 
   describe "create_changeset/3" do
     test "fails if required stuff is missing" do
-      cs = %{valid?: validity} = Address.create_changeset(%Address{}, %{}, %Country{})
-      refute validity
+      cs = Address.create_changeset(%Address{}, %{})
+      refute cs.valid?
 
       assert %{
                address_line_1: ["can't be blank"],
                city: ["can't be blank"],
                first_name: ["can't be blank"],
                last_name: ["can't be blank"],
-               zip_code: ["can't be blank"]
+               zip_code: ["can't be blank"],
+               country: ["country or country_id can't be blank"]
              } = errors_on(cs)
     end
 
     test "fails when address_line_1 is less than 10 chars long" do
-      short = %{@valid_params | address_line_1: "123456789"}
+      short = %{@params | address_line_1: "123456789"}
 
-      cs = %{valid?: validity} = Address.create_changeset(%Address{}, short, %Country{})
-      refute validity
+      cs = Address.create_changeset(%Address{}, short)
+      refute cs.valid?
 
       assert %{
-               address_line_1: ["should be at least 10 character(s)"]
+               address_line_1: ["should be at least 10 character(s)"],
+               country: ["country or country_id can't be blank"]
              } = errors_on(cs)
     end
   end
@@ -45,33 +51,103 @@ defmodule Snitch.Data.Schema.AddressTest do
     setup :states
     setup :countries
 
-    test "with valid params", %{states: [state]} do
-      %{valid?: validity} =
-        Address.create_changeset(%Address{}, @valid_params, state.country, state)
+    test "succeeds with valid params", %{states: [state]} do
+      params = %{
+        @params
+        | country: state.country,
+          state: state
+      }
+
+      %{valid?: validity} = Address.create_changeset(%Address{}, params)
+      assert validity
+
+      params = %{
+        @params
+        | country_id: state.country_id,
+          state_id: state.id
+      }
+
+      %{valid?: validity} = Address.create_changeset(%Address{}, params)
+      assert validity
+    end
+
+    test "succeeds w/o state/state_id if it is not needed in country", %{countries: [country]} do
+      params = %{
+        @params
+        | country: %{country | states_required: false}
+      }
+
+      %{valid?: validity} = Address.create_changeset(%Address{}, params)
 
       assert validity
     end
 
-    test "without state if it is not needed in country", %{countries: [country]} do
-      tweaked_country = %{country | states_required: false}
+    test "fails with bad country_id" do
+      params = %{
+        @params
+        | country_id: -1
+      }
 
-      %{valid?: validity} = Address.create_changeset(%Address{}, @valid_params, tweaked_country)
-
-      assert validity
+      cs = Address.create_changeset(%Address{}, params)
+      refute cs.valid?
+      assert %{country_id: ["does not exist"]} = errors_on(cs)
     end
 
-    test "fails without state if it is needed", %{countries: [country]} do
+    test "fails with bad state_id", %{countries: [country]} do
+      params = %{
+        @params
+        | country: country,
+          state_id: -1
+      }
+
+      cs = Address.create_changeset(%Address{}, params)
+      refute cs.valid?
+      assert %{state_id: ["does not exist"]} = errors_on(cs)
+    end
+
+    test "fails without state if it was needed by country", %{countries: [country]} do
       assert country.states_required
-      cs = %{valid?: validity} = Address.create_changeset(%Address{}, @valid_params, country)
-      refute validity
+
+      params = %{
+        @params
+        | country_id: country.id
+      }
+
+      cs = Address.create_changeset(%Address{}, params)
+      refute cs.valid?
+      assert %{state: ["state is required for this country"]} = errors_on(cs)
+
+      params = %{
+        @params
+        | country: country
+      }
+
+      cs = Address.create_changeset(%Address{}, params)
+      refute cs.valid?
       assert %{state: ["state is required for this country"]} = errors_on(cs)
     end
 
     test "fails if state.country different from country", %{states: [state], countries: [country]} do
-      cs =
-        %{valid?: validity} = Address.create_changeset(%Address{}, @valid_params, country, state)
+      params = %{
+        @params
+        | country: country,
+          state: state
+      }
 
-      refute validity
+      cs = Address.create_changeset(%Address{}, params)
+
+      refute cs.valid?
+      assert %{state: ["state does not belong to country"]} = errors_on(cs)
+
+      params = %{
+        @params
+        | country_id: country.id,
+          state_id: state.id
+      }
+
+      cs = Address.create_changeset(%Address{}, params)
+
+      refute cs.valid?
       assert %{state: ["state does not belong to country"]} = errors_on(cs)
     end
   end


### PR DESCRIPTION
## Motivation
Pivotal story: [#158236559](https://www.pivotaltracker.com/story/show/158236559)
The address changeset function could not be used in a `cast_assoc/3`, hence the need to refactor.

## Description
Renamed `create_changeset/4` to `changset/2`

The changeset function no longer accepts state and country structs. This saves unnecessary complication in their validation. `changeset/2` can be used for both creation and update!
Moreover, when controllers will invoke the function for creation _or_ update, they would not be able to "load" state and country structs (it is also not their responsibility).
The validation logic is also much more readable.

## Gotchas! :shield: 
@arjun289  I've not used `fetch_change`, pls forgive me :stuck_out_tongue: 
The changeset loads at-most 1 country record and additionally at-most 1 state record to perform the validation.
The funny thing about this changeset is that it does DB level validations _in situ_, not when the changeset is consumed by some `Repo` function. 
> I challenge the brave to refactor the validation clauses and improve them :nerd_face: 
------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
  > Is this critical for this PR??
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards](commit-template).

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt
