### PR TITLE
Fix typo in creating github hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ We strongly recommend that you set up these git hooks on your machine by:
 # in the project root, run:
 ln -sf ../../.scripts/pre-commit .git/hooks/pre-commit
 ln -sf ../../.scripts/post-commit .git/hooks/post-commit
+
+# Yeah you read that right! Two folders up is necessary.
+# See: https://stackoverflow.com/questions/4592838/symbolic-link-to-a-hook-in-git#4594681
 ```
 
 > **Note that our CI will fail your PR if you dont run `mix format` in the project
@@ -45,3 +48,4 @@ Have fun commiting new changes! :rainbow:
 [dev]: https://github.com/aviabird/snitch/tree/develop
 [commit-format]: https://chris.beams.io/posts/git-commit/
 [our-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->
Edited the path for `.scripts` while creating symbolic links in creating github hooks

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards](commit-template).

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-template]: https://github.com/aviabird/snitch/blob/develop/.git_commit_msg.txt
