### PR TITLE
Option type CRUD for admin

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
@@ -1,0 +1,82 @@
+defmodule AdminAppWeb.OptionTypeController do
+  use AdminAppWeb, :controller
+  alias Snitch.Data.Model.OptionType, as: OTModel
+  alias Snitch.Data.Schema.OptionType, as: OTSchema
+
+  def index(conn, _params) do
+    option_types = OTModel.get_all()
+    render(conn, "index.html", %{option_types: option_types})
+  end
+
+  def new(conn, _params) do
+    changeset = OTSchema.create_changeset(%OTSchema{}, %{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"option_type" => params}) do
+    case OTModel.create(params) do
+      {:ok, _} ->
+        option_types = OTModel.get_all()
+        render(conn, "index.html", %{option_types: option_types})
+
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: %{changeset | action: :new})
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    with {id, _} <- Integer.parse(id),
+         %OTSchema{} = option_type <- OTModel.get(id) do
+      changeset = OTSchema.update_changeset(option_type, %{})
+      render(conn, "edit.html", changeset: changeset)
+    else
+      :error ->
+        conn
+        |> put_flash(:info, "Invalid id #{id}")
+        |> redirect(to: option_type_path(conn, :index))
+
+      nil ->
+        conn
+        |> put_flash(:info, "No resource found")
+        |> redirect(to: option_type_path(conn, :index))
+    end
+  end
+
+  def update(conn, %{"id" => id, "option_type" => params}) do
+    with {id, _} <- Integer.parse(id),
+         option_type <- OTModel.get(id),
+         _ <- OTModel.update(option_type, params) do
+      option_types = OTModel.get_all()
+      render(conn, "index.html", %{option_types: option_types})
+    else
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: %{changeset | action: :edit})
+
+      :error ->
+        conn
+        |> halt()
+        |> put_flash(:info, "Invalid id #{id}")
+        |> redirect(to: option_type_path(conn, :index))
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    with {id, _} <- Integer.parse(id),
+         {:ok, option_type} <- OTModel.delete(id) do
+      conn
+      |> put_flash(:info, "Option type #{option_type.name} deleted successfully")
+      |> redirect(to: option_type_path(conn, :index))
+    else
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Failed to delete option type")
+        |> redirect(to: option_type_path(conn, :index))
+
+      :error ->
+        conn
+        |> halt()
+        |> put_flash(:info, "Invalid id #{id}")
+        |> redirect(to: option_type_path(conn, :index))
+    end
+  end
+end

--- a/apps/admin_app/lib/admin_app_web/router.ex
+++ b/apps/admin_app/lib/admin_app_web/router.ex
@@ -26,6 +26,7 @@ defmodule AdminAppWeb.Router do
 
     resources("/tax_categories", TaxCategoryController, only: [:index, :new, :create])
     resources("/stock_locations", StockLocationController)
+    resources("/option_types", OptionTypeController)
   end
 
   # Other scopes may use custom stacks.

--- a/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
@@ -3,7 +3,14 @@
     <ul id="drilldown" class="nav nav-pills nav-stacked col-3">
         <li><a class="nav-link" href="/orders">Orders</a></li>
         <li><a class="nav-link" href="#">Returns</a></li>
-        <li><a class="nav-link" href="#">Products</a></li>
+        <li>
+          <a class="nav-link" href="#" data-toggle="collapse" data-target="#drilldown-2">
+            Products
+          </a>
+          <ul id="drilldown-2" class="nav nav-pills nav-stacked collapse pl-3">
+            <li><a class="nav-link" href="/option_types">Option Types</a></li>
+          </ul>
+        </li>
         <li><a class="nav-link" href="#">Reports</a></li>
         <li>
           <a class="nav-link" href="#" data-toggle="collapse" data-target="#drilldown-1">

--- a/apps/admin_app/lib/admin_app_web/templates/option_type/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/option_type/edit.html.eex
@@ -1,0 +1,2 @@
+<h4>Edit Option Type</h4>
+<%= render "form.html", changeset: @changeset, conn: @conn, action: option_type_path(@conn, :update, @changeset.data) %>

--- a/apps/admin_app/lib/admin_app_web/templates/option_type/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/option_type/form.html.eex
@@ -1,0 +1,5 @@
+<%= form_for @changeset, @action, fn f ->  %>
+  <%= input f, :name%>
+  <%= input f, :display_name%>
+  <%= submit "Submit", class: "btn btn-primary submit-btn" %>
+<% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/option_type/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/option_type/index.html.eex
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="col-5">
+    <h2>Option Types</h2>
+  </div>
+  <div class="col-6" align="right">
+    <%= link("Create New", to: option_type_path(@conn, :new), class: "btn btn-primary")%>
+  </div>
+  <div class="col-1"></div>
+</div>
+<div class="row">
+  <div class="col-12">
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col"></th>
+      <th scope="col">Name</th>
+      <th scope="col">Display Name</th>
+      <th actions="col"></th>
+    </tr>
+  </thead>
+  <tbody class="ui-sortable">
+    <%= for item <- @option_types do %>
+    <tr>
+      <th scope="row" class="ui-state-default"></th>
+      <td><%= item.name %></td>
+      <td><%= item.display_name %></td>
+      <td>
+        <div class="float-right">
+        <%= link("Edit", to: option_type_path(@conn, :edit, item.id), class: "btn btn-primary")%>
+        <%= link("Delete", to: option_type_path(@conn, :delete, item.id), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger")%>
+      </div>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+</div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/option_type/new.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/option_type/new.html.eex
@@ -1,0 +1,2 @@
+<h4>New Option Type</h4>
+<%= render "form.html", changeset: @changeset, conn: @conn, action: option_type_path(@conn, :create) %>

--- a/apps/admin_app/lib/admin_app_web/views/option_type_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/option_type_view.ex
@@ -1,0 +1,3 @@
+defmodule AdminAppWeb.OptionTypeView do
+  use AdminAppWeb, :view
+end

--- a/apps/snitch_core/lib/core/data/model/option_type.ex
+++ b/apps/snitch_core/lib/core/data/model/option_type.ex
@@ -1,0 +1,54 @@
+defmodule Snitch.Data.Model.OptionType do
+  @moduledoc """
+  OptionType API
+  """
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.OptionType
+
+  @doc """
+  Create a OptionType with supplied params
+  """
+  @spec create(map) :: {:ok, OptionType.t()} | {:error, Ecto.Changeset.t()}
+  def create(params) do
+    QH.create(OptionType, params, Repo)
+  end
+
+  @doc """
+  Returns all OptionTypes
+  """
+  @spec get_all() :: [OptionType.t()]
+  def get_all do
+    Repo.all(OptionType)
+  end
+
+  @doc """
+  Returns an OptionType
+
+  Takes OptionType id as input
+  """
+  @spec get(integer) :: OptionType.t() | nil
+  def get(id) do
+    QH.get(OptionType, id, Repo)
+  end
+
+  @doc """
+  Update the OptionType with supplied params and OptionType instance
+  """
+  @spec update(OptionType.t(), map) :: {:ok, OptionType.t()} | {:error, Ecto.Changeset.t()}
+  def update(model, params) do
+    QH.update(OptionType, params, model, Repo)
+  end
+
+  @doc """
+  Deletes the OptionType
+  """
+  @spec delete(non_neg_integer | struct()) ::
+          {:ok, OptionType.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def delete(id) when is_integer(id) do
+    QH.delete(OptionType, id, Repo)
+  end
+
+  def delete(%OptionType{} = instance) do
+    QH.delete(OptionType, instance, Repo)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/option_type.ex
+++ b/apps/snitch_core/lib/core/data/schema/option_type.ex
@@ -1,0 +1,42 @@
+defmodule Snitch.Data.Schema.OptionType do
+  @moduledoc """
+  Models an OptionType
+  """
+  use Snitch.Data.Schema
+
+  alias Snitch.Data.Schema.TemplateOptionValue
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_option_types" do
+    field(:name, :string)
+    field(:display_name, :string)
+
+    has_many(:template_option_values, TemplateOptionValue)
+    timestamps()
+  end
+
+  @create_params ~w(name display_name)a
+
+  @doc """
+  Returns a changeset to create new OptionType
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(model, params) do
+    common_changeset(model, params)
+  end
+
+  @doc """
+  Returns a changeset to update a OptionType
+  """
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(model, params) do
+    common_changeset(model, params)
+  end
+
+  defp common_changeset(model, params) do
+    model
+    |> cast(params, @create_params)
+    |> validate_required(@create_params)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/template_option_value.ex
+++ b/apps/snitch_core/lib/core/data/schema/template_option_value.ex
@@ -1,0 +1,17 @@
+defmodule Snitch.Data.Schema.TemplateOptionValue do
+  @moduledoc """
+  Models Option Values
+  """
+  use Snitch.Data.Schema
+
+  alias Snitch.Data.Schema.OptionType
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_template_option_values" do
+    field(:value, :string)
+
+    belongs_to(:option_type, OptionType)
+    timestamps()
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180622101026_add_optiontype.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180622101026_add_optiontype.exs
@@ -1,0 +1,20 @@
+defmodule Snitch.Repo.Migrations.AddOptionType do
+  use Ecto.Migration
+
+  def change do
+    create table("snitch_option_types") do
+      add :name, :string
+      add :display_name, :string
+      timestamps()
+    end
+
+    create table("snitch_template_option_values") do
+      add :value, :string
+      add :display_name, :string
+      add :option_type_id, references("snitch_option_types", on_delete: :delete_all), null: false
+      timestamps()
+    end
+
+    create unique_index("snitch_option_types", [:name])
+  end
+end


### PR DESCRIPTION
Adds CRUD for option type in admin section
Pivotal story: [#155104593](https://www.pivotaltracker.com/story/show/155104593)

## Motivation and Context
Option types are required to create prototype for product

## Describe your changes
- Adds migration, model and schema for option type
- Adds controllers, templates in admin app for UI

------

Following things can be revisted later on:
- Test [158591350](https://www.pivotaltracker.com/story/show/158591350)
- Template option values [158591428](https://www.pivotaltracker.com/story/show/158591428)
- Set option type order to display on UI [158622532](https://www.pivotaltracker.com/story/show/158622532)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
