### PR TITLE
Refactor order, line-item changesets

### DIFF
--- a/apps/snitch_core/lib/core/tools/validations.ex
+++ b/apps/snitch_core/lib/core/tools/validations.ex
@@ -22,7 +22,7 @@ defmodule Snitch.Tools.Validations do
     case fetch_change(changeset, key) do
       {:ok, %Money{amount: amount}} ->
         if Decimal.cmp(Decimal.reduce(amount), Decimal.new(0)) == :lt do
-          add_error(changeset, key, "must be greater than 0", validation: :number)
+          add_error(changeset, key, "must be equal or greater than 0", validation: :number)
         else
           changeset
         end

--- a/apps/snitch_core/priv/repo/migrations/20180614172359_remove_order_confirmed_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180614172359_remove_order_confirmed_field.exs
@@ -1,0 +1,15 @@
+defmodule Snitch.Repo.Migrations.RemoveOrderConfirmedField do
+  use Ecto.Migration
+
+  def up do
+    alter table("snitch_orders") do
+      remove(:confirmed?)
+    end
+  end
+
+  def down do
+    alter table("snitch_orders") do
+      add(:confirmed, :boolean, default: false)
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180626070214_remove_order_not_null_on_total_fields.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180626070214_remove_order_not_null_on_total_fields.exs
@@ -1,0 +1,21 @@
+defmodule Snitch.Repo.Migrations.RemoveOrderNotNullOnTotalFields do
+  use Ecto.Migration
+
+  def up do
+    alter table("snitch_orders") do
+      modify :total, :money_with_currency, null: true
+      modify :item_total, :money_with_currency, null: true
+      modify :adjustment_total, :money_with_currency, null: true
+      modify :promo_total, :money_with_currency, null: true
+    end
+  end
+
+  def down do
+    alter table("snitch_orders") do
+      modify :total, :money_with_currency, null: false
+      modify :item_total, :money_with_currency, null: false
+      modify :adjustment_total, :money_with_currency, null: false
+      modify :promo_total, :money_with_currency, null: false
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/orders.ex
+++ b/apps/snitch_core/priv/repo/seed/orders.ex
@@ -15,10 +15,10 @@ defmodule Snitch.Seed.Orders do
     user_id: nil,
     billing_address: nil,
     shipping_address: nil,
-    adjustment_total: Money.new(0, :USD),
-    promo_total: Money.new(0, :USD),
-    item_total: Money.new(0, :USD),
-    total: Money.new(0, :USD),
+    adjustment_total: nil,
+    promo_total: nil,
+    item_total: nil,
+    total: nil,
     inserted_at: DateTime.utc(),
     updated_at: DateTime.utc()
   }

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -2,8 +2,8 @@ defmodule Snitch.Data.Model.LineItemTest do
   use ExUnit.Case, async: true
   use Snitch.DataCase
 
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
   import Snitch.Factory
-  import Mox
 
   alias Snitch.Data.Model.LineItem
 

--- a/apps/snitch_core/test/data/model/package_test.exs
+++ b/apps/snitch_core/test/data/model/package_test.exs
@@ -131,8 +131,8 @@ defmodule Snitch.Data.Model.PackageTest do
       {:error, cs} = Package.update(package, bad_params)
 
       assert %{
-               cost: ["must be greater than 0"],
-               tax_total: ["must be greater than 0"]
+               cost: ["must be equal or greater than 0"],
+               tax_total: ["must be equal or greater than 0"]
              } = errors_on(cs)
     end
   end

--- a/apps/snitch_core/test/data/model/payment/card_payment_test.exs
+++ b/apps/snitch_core/test/data/model/payment/card_payment_test.exs
@@ -12,14 +12,14 @@ defmodule Snitch.Data.Model.CardPaymentTest do
   setup :cards
   setup :card_payment
 
-  test "create", %{payment: payment, order: order} do
+  test "create", %{payment: payment} do
     assert payment.state == "some-state"
-    assert payment.amount == order.total
+    assert payment.amount == Money.zero(:USD)
   end
 
   test "update", %{card_payment: card_payment, payment: payment} do
     card_params = %{cvv_response: "Z", avs_response: "V"}
-    payment_params = %{amount: Money.new(0, :USD), state: "complete"}
+    payment_params = %{amount: Money.new(-1, :USD), state: "complete"}
 
     assert {:ok, %{payment: updated_payment, card_payment: updated_card_payment}} =
              CardPayment.update(card_payment, card_params, payment_params)
@@ -32,7 +32,11 @@ defmodule Snitch.Data.Model.CardPaymentTest do
 
   defp card_payment(context) do
     %{order: order, cards: [card | _]} = context
-    params = %{amount: order.total, state: "some-state"}
+
+    params = %{
+      amount: Money.zero(:USD),
+      state: "some-state"
+    }
 
     {:ok, %{payment: payment, card_payment: card_payment}} =
       CardPayment.create("card-payment", order.id, params, %{card: Map.from_struct(card)})

--- a/apps/snitch_core/test/data/schema/line_item_test.exs
+++ b/apps/snitch_core/test/data/schema/line_item_test.exs
@@ -1,0 +1,141 @@
+defmodule Snitch.Data.Schema.LineItemTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Ecto.Changeset
+  alias Snitch.Data.Schema.LineItem
+  alias Snitch.Data.Model.LineItem, as: LineItemModel
+
+  @params %{
+    order_id: nil,
+    variant_id: nil,
+    quantity: 1,
+    unit_price: nil,
+    total: nil
+  }
+
+  setup :variants
+
+  setup do
+    user = insert(:user)
+
+    [
+      user: user,
+      order: insert(:order, user_id: user.id)
+    ]
+  end
+
+  describe "create_changeset/2" do
+    test "fails with empty params" do
+      cs = LineItem.create_changeset(%LineItem{}, %{})
+
+      assert %{
+               order_id: ["can't be blank"],
+               quantity: ["can't be blank"],
+               total: ["can't be blank"],
+               unit_price: ["can't be blank"],
+               variant_id: ["can't be blank"]
+             } = errors_on(cs)
+    end
+
+    test "fails without price fields", %{order: order, variants: [variant | _]} do
+      cs =
+        LineItem.create_changeset(%LineItem{}, %{
+          @params
+          | variant_id: variant.id,
+            order_id: order.id
+        })
+
+      assert %{
+               total: ["can't be blank"],
+               unit_price: ["can't be blank"]
+             } = errors_on(cs)
+    end
+
+    test "fails with bad price fields", %{order: order, variants: [variant | _]} do
+      cs =
+        LineItem.create_changeset(%LineItem{}, %{
+          @params
+          | variant_id: variant.id,
+            order_id: order.id,
+            unit_price: Money.new(-1, :USD),
+            total: Money.new(-2, :USD)
+        })
+
+      assert %{
+               total: ["must be equal or greater than 0"],
+               unit_price: ["must be equal or greater than 0"]
+             } = errors_on(cs)
+    end
+
+    test "with price fields", %{order: order, variants: [variant | _]} do
+      cs =
+        LineItem.create_changeset(%LineItem{}, %{
+          @params
+          | variant_id: variant.id,
+            order_id: order.id,
+            unit_price: Money.new(0, :USD),
+            total: Money.new(0, :USD)
+        })
+
+      assert cs.valid?
+
+      [params_with_price] =
+        LineItemModel.update_price_and_totals([
+          %{@params | variant_id: variant.id, order_id: order.id}
+        ])
+
+      cs = LineItem.create_changeset(%LineItem{}, params_with_price)
+      assert cs.valid?
+    end
+  end
+
+  describe "update_changeset/2" do
+    setup %{order: order, variants: [variant | _]} do
+      cs =
+        LineItem.create_changeset(%LineItem{}, %{
+          @params
+          | variant_id: variant.id,
+            order_id: order.id,
+            unit_price: Money.new(2, :USD),
+            total: Money.new(2, :USD)
+        })
+
+      [line_item: Changeset.apply_changes(cs)]
+    end
+
+    test "fails with only quantity", %{line_item: line_item} do
+      cs = LineItem.update_changeset(line_item, %{quantity: line_item.quantity + 1})
+      refute cs.valid?
+      assert %{total: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "fails with only unit_price", %{line_item: line_item} do
+      cs =
+        LineItem.update_changeset(line_item, %{unit_price: Money.mult!(line_item.unit_price, 2)})
+
+      refute cs.valid?
+      assert %{total: ["can't be blank"]} = errors_on(cs)
+    end
+
+    test "with empty params", %{line_item: line_item} do
+      cs = LineItem.update_changeset(line_item, %{})
+      assert cs.valid?
+    end
+
+    test "with valid params", %{line_item: line_item} do
+      cs =
+        LineItem.update_changeset(line_item, %{
+          @params
+          | variant_id: 1,
+            unit_price: Money.new(2, :USD),
+            total: Money.new(2, :USD)
+        })
+
+      assert cs.valid?
+      refute Map.has_key?(cs.changes, :variant_id)
+    end
+  end
+end

--- a/apps/snitch_core/test/data/schema/order_test.exs
+++ b/apps/snitch_core/test/data/schema/order_test.exs
@@ -20,96 +20,171 @@ defmodule Snitch.Data.Schema.OrderTest do
     country_id: nil
   }
 
+  @order_params %{
+    adjustment_total: nil,
+    promo_total: nil,
+    item_total: nil,
+    total: nil,
+    line_items: nil,
+    user_id: nil
+  }
+
   setup :variants
   setup :user_with_address
-  setup :some_line_items
-  setup :order_changeset
 
-  @tag line_item_type: :valid
-  test "order totals are updated and line_items are inserted to DB", context do
-    %{order: order} = context
-    %{valid?: validity, changes: changes} = order
+  test "both order and line_items are inserted to DB", context do
+    %{user: user, variants: variants} = context
+    line_items = line_item_params(variants)
+    item_total = total(line_items)
+
+    params = %{
+      @order_params
+      | item_total: item_total,
+        total: item_total,
+        user_id: user.id,
+        line_items: line_items
+    }
+
+    cs = Order.create_changeset(build(:order), params)
+
+    %{
+      valid?: validity,
+      changes: %{
+        item_total: _,
+        total: _,
+        line_items: _line_item_changesets
+      }
+    } = cs
+
     assert validity
-    assert Map.has_key?(changes, :item_total)
-    assert Enum.all?(changes.line_items, fn %{action: action} -> action == :insert end)
-    # check DB level constraints too
-    assert {:ok, _} = Repo.insert(order)
+    assert cs.changes.item_total == item_total
+    assert cs.changes.total == item_total
+    assert {:ok, _} = Repo.insert(cs)
   end
 
-  @tag line_item_type: :duplicate
-  test "order can handle duplicate line_items", context do
-    %{order: order} = context
-    %{valid?: validity, changes: changes, errors: [error]} = order
+  test "order can handle duplicate line_items", %{user: user, variants: [v | _]} do
+    params = %{
+      @order_params
+      | user_id: user.id,
+        line_items: line_item_params([v, v])
+    }
+
+    cs = Order.create_changeset(build(:order), params)
+
+    %{
+      valid?: validity,
+      changes: %{
+        line_items: line_item_changesets
+      }
+    } = cs
+
     refute validity
-    refute Map.has_key?(changes, :item_total)
-    assert Enum.all?(changes.line_items, fn %{valid?: validity} -> validity end)
-    assert error == {:duplicate_variants, {"line_items must have unique variant_ids", []}}
+    assert Enum.all?(line_item_changesets, fn %{valid?: validity} -> validity end)
+    assert %{line_items: ["line_items must have unique variant_ids"]} = errors_on(cs)
   end
 
-  @tag line_item_type: :none
-  test "order cannot be created without line_items", context do
-    %{order: order} = context
-    %{valid?: validity, errors: [error]} = order
-    refute validity
-    assert error == {:line_items, {"can't be blank", [validation: :required]}}
+  test "order can be created without line_items", %{user: user} do
+    params = %{
+      @order_params
+      | user_id: user.id,
+        line_items: []
+    }
+
+    cs = Order.create_changeset(build(:order), params)
+    assert cs.valid?
   end
 
   describe "order updates" do
-    setup :persist
+    setup %{user: user, variants: variants} do
+      line_items = line_item_params(variants)
+      item_total = total(line_items)
 
-    @tag line_item_type: :valid
-    test "unassociated line_items", context do
-      %{persisted: persisted, line_items: line_items} = context
-      params = %{line_items: LineItem.update_price_and_totals(line_items)}
-      new_order = Order.update_changeset(persisted, params)
-      %{valid?: validity, changes: changes} = new_order
+      params = %{
+        @order_params
+        | user_id: user.id,
+          line_items: line_items,
+          item_total: item_total,
+          total: item_total,
+          promo_total: Money.zero(:USD),
+          adjustment_total: Money.zero(:USD)
+      }
 
-      assert validity
-      assert {:ok, _} = Repo.update(new_order)
-      assert Enum.all?(changes.line_items, fn x -> x.action in [:insert, :replace] end)
+      [
+        persisted:
+          :order
+          |> build()
+          |> Order.create_changeset(params)
+          |> Repo.insert!()
+      ]
     end
 
-    @tag line_item_type: :valid
+    test "unassociated line_items", context do
+      %{persisted: persisted, variants: variants} = context
+      params = %{line_items: line_item_params(variants)}
+      cs = Order.update_changeset(persisted, params)
+
+      %{valid?: validity, changes: changes} = cs
+
+      assert validity
+      # 3 old LIs replaced (aka deleted) and 3 new inserted.
+      assert Enum.all?(changes.line_items, fn x -> x.action in [:insert, :replace] end)
+      assert {:ok, order} = Repo.update(cs)
+      assert order.total == persisted.total
+      assert order.item_total == persisted.item_total
+    end
+
     test "quantity, variant", context do
       %{persisted: persisted} = context
       [one, two, three] = persisted.line_items
 
-      new_line_items = [
-        %{id: two.id, variant_id: two.variant_id, quantity: 9},
-        %{id: one.id, variant_id: three.variant_id, quantity: one.quantity},
-        %{id: three.id, variant_id: one.variant_id, quantity: three.quantity}
-      ]
+      line_items =
+        LineItem.update_price_and_totals([
+          %{id: two.id, variant_id: two.variant_id, quantity: 9},
+          %{id: one.id, variant_id: three.variant_id, quantity: one.quantity},
+          %{id: three.id, variant_id: one.variant_id, quantity: three.quantity}
+        ])
 
-      totals = [
-        Money.mult!(two.unit_price, 9),
-        Money.mult!(three.unit_price, one.quantity),
-        Money.mult!(one.unit_price, three.quantity)
-      ]
+      item_total = total(line_items)
 
-      total = Enum.reduce(totals, &Money.add!/2)
-      params = %{line_items: LineItem.update_price_and_totals(new_line_items)}
+      params = %{
+        line_items: line_items,
+        item_total: item_total,
+        total: item_total
+      }
 
-      new_order = Order.update_changeset(persisted, params)
-      %{valid?: validity, changes: changes} = new_order
+      cs = Order.update_changeset(persisted, params)
+      %{valid?: validity, changes: changes} = cs
 
       assert validity
-      assert {:ok, _} = Repo.update(new_order)
-      assert Map.fetch!(changes, :item_total) == Money.reduce(total)
       assert Enum.all?(changes.line_items, fn x -> x.action == :update end)
+      assert {:ok, order} = Repo.update(cs)
+      assert order.item_total == item_total
+      assert order.total == item_total
     end
 
-    @tag line_item_type: :valid
     test "no changes, bud!", context do
       %{persisted: persisted} = context
       [one, two, three] = persisted.line_items
-      new_line_items = [%{id: one.id}, %{id: two.id}, %{id: three.id}]
-      params = %{line_items: LineItem.update_price_and_totals(new_line_items)}
-      new_order = Order.update_changeset(persisted, params)
-      %{valid?: validity, changes: changes} = new_order
 
+      line_items =
+        LineItem.update_price_and_totals([%{id: one.id}, %{id: two.id}, %{id: three.id}])
+
+      item_total = total(persisted.line_items)
+
+      params = %{
+        line_items: line_items,
+        item_total: item_total,
+        total: item_total
+      }
+
+      cs = Order.update_changeset(persisted, params)
+
+      %{valid?: validity, changes: changes} = cs
       assert validity
-      assert {:ok, _} = Repo.update(new_order)
       assert changes == %{}
+      assert {:ok, order} = Repo.update(cs)
+      assert order.item_total == persisted.item_total
+      assert order.total == persisted.total
     end
   end
 
@@ -148,54 +223,34 @@ defmodule Snitch.Data.Schema.OrderTest do
 
       params = %{
         shipping_address: address_params,
-        billing_address: address_params
+        billing_address: address_params,
+        promo_total: Money.zero(:INR)
       }
 
       cs = Order.partial_update_changeset(persisted, params)
       assert cs.valid?
+      assert {:ok, Money.zero(:INR)} == Map.fetch(cs.changes, :promo_total)
       assert {:ok, _} = Repo.update(cs)
     end
   end
 
-  defp some_line_items(context) do
-    %{variants: vs} = context
-    v = List.first(vs)
+  defp line_item_params([]), do: []
 
-    variant_ids =
-      case context[:line_item_type] do
-        :valid ->
-          Stream.map(vs, fn x -> x.id end)
-
-        :duplicate ->
-          [v.id, v.id, v.id]
-
-        _ ->
-          []
-      end
-
+  defp line_item_params(variants) do
     line_items =
-      Enum.into(variant_ids, [], fn variant_id ->
+      variants
+      |> Stream.map(fn x -> x.id end)
+      |> Enum.into([], fn variant_id ->
         %{variant_id: variant_id, quantity: 2}
       end)
 
-    [line_items: line_items]
+    LineItem.update_price_and_totals(line_items)
   end
 
-  defp order_changeset(context) do
-    order = build(:order)
-    %{user: u} = context
-    line_items = Map.get(context, :line_items, [])
-
-    params = %{
-      user_id: u.id,
-      line_items: LineItem.update_price_and_totals(line_items)
-    }
-
-    [order: Order.create_changeset(order, params)]
-  end
-
-  defp persist(%{order: order}) do
-    [persisted: Repo.insert!(order)]
+  defp total(line_items) do
+    line_items
+    |> Stream.map(&Map.fetch!(&1, :total))
+    |> Enum.reduce(&Money.add!/2)
   end
 end
 

--- a/apps/snitch_core/test/data/schema/payment/payment_test.exs
+++ b/apps/snitch_core/test/data/schema/payment/payment_test.exs
@@ -31,6 +31,6 @@ defmodule Snitch.Data.Schema.PaymentTest do
       |> Payment.create_changeset(%{amount: Money.new("-0.0001", :USD)})
 
     assert %Ecto.Changeset{errors: errors} = check_payment
-    assert errors == [amount: {"must be greater than 0", [validation: :number]}]
+    assert errors == [amount: {"must be equal or greater than 0", [validation: :number]}]
   end
 end

--- a/apps/snitch_core/test/data/schema/variant_test.exs
+++ b/apps/snitch_core/test/data/schema/variant_test.exs
@@ -41,14 +41,14 @@ defmodule Snitch.Data.Schema.VariantTest do
       params = %{@valid_params | selling_price: Money.new("-0.01", :USD)}
       cs = %{valid?: validity} = Variant.create_changeset(%Variant{}, params)
       refute validity
-      assert %{selling_price: ["must be greater than 0"]} = errors_on(cs)
+      assert %{selling_price: ["must be equal or greater than 0"]} = errors_on(cs)
     end
 
     test "fails with bad cost price" do
       params = %{@valid_params | cost_price: Money.new("-0.01", :USD)}
       cs = %{valid?: validity} = Variant.create_changeset(%Variant{}, params)
       refute validity
-      assert %{cost_price: ["must be greater than 0"]} = errors_on(cs)
+      assert %{cost_price: ["must be equal or greater than 0"]} = errors_on(cs)
     end
 
     test "fails with duplicate sku" do

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -20,6 +20,10 @@ defmodule Snitch.Factory do
 
   alias Snitch.Repo
 
+  def currency do
+    :USD
+  end
+
   def user_factory do
     %User{
       first_name: sequence(:first_name, &"Tony-#{&1}"),
@@ -36,8 +40,8 @@ defmodule Snitch.Factory do
       height: Decimal.new("0.15"),
       depth: Decimal.new("0.1"),
       width: Decimal.new("0.4"),
-      cost_price: Money.new("9.99", :USD),
-      selling_price: random_price(:USD, 14, 4)
+      cost_price: Money.new("9.99", currency()),
+      selling_price: random_price(currency(), 14, 4)
     }
   end
 
@@ -48,19 +52,15 @@ defmodule Snitch.Factory do
       height: Decimal.new("0.15"),
       depth: Decimal.new("0.1"),
       width: Decimal.new("0.4"),
-      cost_price: Money.new("9.99", :USD),
-      selling_price: Money.new("14.99", :USD)
+      cost_price: Money.new("9.99", currency()),
+      selling_price: Money.new("14.99", currency())
     }
   end
 
   def order_factory do
     %Order{
       number: sequence("order"),
-      state: "cart",
-      adjustment_total: Money.new(0, :USD),
-      promo_total: Money.new(0, :USD),
-      item_total: Money.new(0, :USD),
-      total: Money.new(0, :USD)
+      state: "cart"
     }
   end
 
@@ -155,8 +155,8 @@ defmodule Snitch.Factory do
           order_id: order.id,
           variant_id: v.id,
           quantity: 1,
-          unit_price: v.cost_price,
-          total: v.cost_price
+          unit_price: v.selling_price,
+          total: v.selling_price
         )
       end)
       |> Enum.take(count)


### PR DESCRIPTION
## Motivation
Pivotal stories: [#158235418](https://www.pivotaltracker.com/story/show/158235418) [#158605364](https://www.pivotaltracker.com/story/show/158605364)

Prior to this, we could not make orders with zero line items, and the totals were _forcefuly_ computed in the order changeset.

## Description
Refactored the order and line-item changesets to make them easy to use. This will prepare us to move ahead with the [`Model.LineItem`](https://www.pivotaltracker.com/epic/show/4006523) epic, to allow updating the items in cart irrespective of the order state.
The tests have been refactored as well, to make them more readable (at least IMO :smiley:)
By removing `compute_totals` from the changeset, we have gained more freedom, reduced coupling at the cost of the guarantee that:
> no matter what state the order is in, the totals will be accurate.

We don't really need such a "loose" guarantee.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
