### PR TITLE
LineItem CRUD for orders in cart state

### DIFF
--- a/apps/snitch_core/lib/core/data/model/line_item.ex
+++ b/apps/snitch_core/lib/core/data/model/line_item.ex
@@ -4,8 +4,55 @@ defmodule Snitch.Data.Model.LineItem do
   """
   use Snitch.Data.Model
 
+  alias Ecto.Multi
+  alias Snitch.Data.Model.Order, as: OrderModel
   alias Snitch.Data.Schema.{LineItem, Variant}
+  alias Snitch.Domain.Order, as: OrderDomain
   alias Snitch.Tools.Money, as: MoneyTools
+
+  @doc """
+  Creates a new `line_item` for an existing order referenced by `params.order_id`.
+
+  This may also update some associated entities like, `Order`, `Package`,
+  etc. in the same DB transaction.
+
+  Returns the newly inserted `line_item` with the order, and all line items preloaded.
+  Other updated associations may or may not be preloaded.
+  """
+  @spec create(map) :: LineItem.t()
+  def create(params) do
+    Multi.new()
+    |> Multi.insert(:line_item, LineItem.create_changeset(%LineItem{}, params))
+    |> do_operation(&OrderDomain.add_line_item/2)
+  end
+
+  @doc """
+  Updates `line_item`, and possibly other associations in the same DB transaction.
+
+  Returns the newly inserted `line_item` with the order and all line items preloaded.
+  Other updated associations may or may not be preloaded.
+  """
+  @spec update(LineItem.t(), map) :: LineItem.t()
+  def update(%LineItem{} = line_item, params) do
+    Multi.new()
+    |> Multi.update(:line_item, LineItem.update_changeset(line_item, params))
+    |> do_operation(&OrderDomain.update_line_item/2)
+  end
+
+  @doc """
+  Deletes `line_item`, and possibly updates other associations in the same DB transaction.
+
+  Returns the deleted `line_item` with the order and all line items preloaded.
+  > The deleted line item will not be in the assoc list.
+
+  Other updated associations may or may not be preloaded.
+  """
+  @spec delete(LineItem.t()) :: LineItem.t()
+  def delete(%LineItem{} = line_item) do
+    Multi.new()
+    |> Multi.delete(:line_item, line_item)
+    |> do_operation(&OrderDomain.remove_line_item/2)
+  end
 
   @spec get(map) :: LineItem.t() | nil
   def get(query_fields) do
@@ -47,6 +94,8 @@ defmodule Snitch.Data.Model.LineItem do
   ```
   """
   @spec update_price_and_totals([map]) :: [map]
+  def update_price_and_totals([]), do: []
+
   def update_price_and_totals(line_items) do
     unit_selling_prices =
       line_items
@@ -83,6 +132,31 @@ defmodule Snitch.Data.Model.LineItem do
       |> Map.put(:total, total)
     else
       _ -> line_item
+    end
+  end
+
+  @spec do_operation(Ecto.Multi.t(), (Order.t(), LineItem.t() -> {:ok | :error, term})) ::
+          LineItem.t()
+  defp do_operation(multi, order_updater) do
+    multi
+    |> Multi.run(:fetch_order, fn %{line_item: line_item} ->
+      {
+        :ok,
+        line_item.order_id
+        |> OrderModel.get()
+        |> Repo.preload([:line_items])
+      }
+    end)
+    |> Multi.run(:updated_order, fn %{fetch_order: order, line_item: line_item} ->
+      order_updater.(order, line_item)
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{line_item: line_item, updated_order: order}} ->
+        {:ok, struct(line_item, order: order)}
+
+      error ->
+        error
     end
   end
 end

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -3,6 +3,7 @@ defmodule Snitch.Data.Model.Order do
   Order API
   """
   use Snitch.Data.Model
+
   alias Snitch.Data.Schema.Order
   alias Snitch.Data.Model.LineItem, as: LineItemModel
 
@@ -112,8 +113,8 @@ defmodule Snitch.Data.Model.Order do
   @doc """
   Updates the order with supplied `params`. Does not update line_items.
   """
-  @spec partial_update(map, Order.t()) :: {:ok, Order.t()} | {:error, Ecto.Changeset.t()}
-  def partial_update(params, order \\ nil) do
+  @spec partial_update(Order.t(), map) :: {:ok, Order.t()} | {:error, Ecto.Changeset.t()}
+  def partial_update(order, params) do
     order
     |> Order.partial_update_changeset(params)
     |> Repo.update()
@@ -132,9 +133,6 @@ defmodule Snitch.Data.Model.Order do
 
   @spec get_all() :: [Order.t()]
   def get_all, do: Repo.all(Order)
-
-  # Compute price totals only if line_items are provided
-  defp update_line_item_costs([]), do: []
 
   defp update_line_item_costs(line_items) when is_list(line_items) do
     LineItemModel.update_price_and_totals(line_items)

--- a/apps/snitch_core/lib/core/domain/order/order.ex
+++ b/apps/snitch_core/lib/core/domain/order/order.ex
@@ -1,0 +1,15 @@
+defmodule Snitch.Domain.Order do
+  @moduledoc """
+  Order helpers
+  """
+
+  use Snitch.Domain
+
+  alias Snitch.Data.Schema.Order
+
+  def add_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
+
+  def update_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
+
+  def remove_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
+end

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -8,7 +8,8 @@ defmodule Snitch.Data.Model.LineItemTest do
   alias Snitch.Data.Model.LineItem
 
   describe "with valid params" do
-    setup [:variants, :good_line_items]
+    setup :variants
+    setup :good_line_items
 
     test "update_price_and_totals/1", context do
       %{line_items: line_items, totals: totals} = context
@@ -24,7 +25,8 @@ defmodule Snitch.Data.Model.LineItemTest do
   end
 
   describe "with invalid params" do
-    setup [:variants, :bad_line_items]
+    setup :variants
+    setup :bad_line_items
 
     test "update_price_and_totals/1", context do
       %{line_items: line_items} = context
@@ -49,6 +51,150 @@ defmodule Snitch.Data.Model.LineItemTest do
       assert_raise RuntimeError, "whatever", fn ->
         LineItem.compute_total([])
       end
+    end
+  end
+
+  describe "create/1" do
+    setup :variants
+    setup :user_with_address
+
+    @tag variant_count: 1
+    test "fails without an existing order", %{variants: [v]} do
+      assert {:error, :line_item, changeset, %{}} =
+               LineItem.create(%{line_item_params(v) | order_id: -1})
+
+      assert %{order_id: ["does not exist"]} = errors_on(changeset)
+
+      assert {:error, :line_item, changeset, %{}} = LineItem.create(line_item_params(v))
+
+      assert %{order_id: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+
+  describe "create/1 for order in `cart` state" do
+    setup :variants
+    setup :user_with_address
+
+    @tag variant_count: 1
+    test "which is empty", %{variants: [v], user: user} do
+      order = insert(:order, line_items: [], user: user)
+
+      {:ok, li} = LineItem.create(%{line_item_params(v) | order_id: order.id})
+      assert Ecto.assoc_loaded?(li.order)
+      assert Ecto.assoc_loaded?(li.order.line_items)
+      assert length(li.order.line_items) == 1
+    end
+
+    @tag variant_count: 2
+    test "with existing line_items", %{variants: [v1, v2], user: user} do
+      order = insert(:order, user: user)
+      order = struct(order, line_items(%{order: order, variants: [v1]}))
+
+      assert length(order.line_items) == 1
+      [li] = order.line_items
+      assert li.variant_id == v1.id
+
+      {:ok, li} = LineItem.create(%{line_item_params(v2) | order_id: order.id})
+      assert Ecto.assoc_loaded?(li.order)
+      assert Ecto.assoc_loaded?(li.order.line_items)
+      assert length(li.order.line_items) == 2
+    end
+  end
+
+  describe "update/1 for order in `cart` state" do
+    setup :variants
+    setup :user_with_address
+
+    @tag variant_count: 1
+    test "fails with invalid params", %{variants: [v], user: user} do
+      order = insert(:order, user: user)
+      order = struct(order, line_items(%{order: order, variants: [v]}))
+
+      [li] = order.line_items
+
+      params = %{
+        quantity: li.quantity + 1
+      }
+
+      {:error, :line_item, cs, %{}} = LineItem.update(li, params)
+      assert %{total: ["can't be blank"]} = errors_on(cs)
+    end
+
+    @tag variant_count: 1
+    test "with valid params", %{variants: [v], user: user} do
+      order = insert(:order, user: user)
+      order = struct(order, line_items(%{order: order, variants: [v]}))
+
+      [li] = order.line_items
+
+      params = %{
+        quantity: li.quantity + 1,
+        total: Money.add!(li.total, li.unit_price)
+      }
+
+      {:ok, li} = LineItem.update(li, params)
+      assert Ecto.assoc_loaded?(li.order)
+      assert Ecto.assoc_loaded?(li.order.line_items)
+      assert length(li.order.line_items) == 1
+    end
+  end
+
+  describe "delete/1 for order in `cart` state" do
+    setup :variants
+    setup :user_with_address
+
+    @tag variant_count: 1
+    test "with valid params", %{variants: [v], user: user} do
+      order = insert(:order, user: user)
+      order = struct(order, line_items(%{order: order, variants: [v]}))
+
+      [line_item] = order.line_items
+
+      {:ok, li} = LineItem.delete(line_item)
+      assert Ecto.assoc_loaded?(li.order)
+      assert Ecto.assoc_loaded?(li.order.line_items)
+      assert [] = li.order.line_items
+    end
+  end
+
+  describe "create/1 for order in `address` state" do
+    setup :variants
+    setup :user_with_address
+
+    @tag :skip
+    @tag variant_count: 1
+    test "which is empty", %{variants: [v], user: user} do
+      order = insert(:order, line_items: [], user: user)
+
+      {:ok, li} = LineItem.create(%{line_item_params(v) | order_id: order.id})
+      assert Ecto.assoc_loaded?(li.order)
+      assert Ecto.assoc_loaded?(li.order.line_items)
+      assert length(li.order.line_items) == 1
+      assert order.item_total == li.total
+      assert order.total == li.total
+    end
+
+    @tag :skip
+    @tag variant_count: 2
+    test "with existing line_items", %{variants: [v1, v2], user: user} do
+      order =
+        insert(
+          :order,
+          item_total: v1.selling_price,
+          total: v1.selling_price,
+          user: user,
+          state: "address"
+        )
+
+      order = struct(order, line_items(%{order: order, variants: [v1]}))
+
+      assert length(order.line_items) == 1
+      [li] = order.line_items
+      assert li.variant_id == v1.id
+
+      {:ok, li} = LineItem.create(%{line_item_params(v2) | order_id: order.id})
+      assert Money.reduce(li.order.item_total) == Money.add!(li.total, v1.selling_price)
+      assert Money.reduce(li.order.total) == Money.add!(li.total, v1.selling_price)
     end
   end
 
@@ -81,7 +227,17 @@ defmodule Snitch.Data.Model.LineItemTest do
         %{variant_id: variant.id, quantity: quantity}
       end)
 
-    [line_items: line_items, totals: [nil, nil, nil]]
+    [line_items: line_items]
+  end
+
+  defp line_item_params(variant) do
+    %{
+      quantity: 1,
+      unit_price: variant.selling_price,
+      total: variant.selling_price,
+      order_id: nil,
+      variant_id: variant.id
+    }
   end
 end
 

--- a/apps/snitch_core/test/data/model/order_test.exs
+++ b/apps/snitch_core/test/data/model/order_test.exs
@@ -5,6 +5,7 @@ defmodule Snitch.Data.Model.OrderTest do
   import Snitch.Factory
 
   alias Snitch.Data.Model.{LineItem, Order}
+  alias Snitch.Data.Model.Order
 
   setup :variants
   setup :user_with_address
@@ -113,7 +114,7 @@ defmodule Snitch.Data.Model.OrderTest do
     test "params only", %{order_params: order_params} do
       {:ok, order} = Order.create(order_params)
 
-      {:ok, new_order} = Order.partial_update(%{state: "foo"}, order)
+      {:ok, new_order} = Order.partial_update(order, %{state: "foo"})
       assert extract_ids(order.line_items) == extract_ids(new_order.line_items)
       assert new_order.state == "foo"
     end

--- a/apps/snitch_core/test/domain/order/order_test.exs
+++ b/apps/snitch_core/test/domain/order/order_test.exs
@@ -1,0 +1,25 @@
+defmodule Snitch.Domain.OrderTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  alias Snitch.Data.Schema.Order
+  alias Snitch.Domain.Order, as: OrderDomain
+
+  describe "add_line_item/2" do
+    test "when order.state is `cart`" do
+      assert {:ok, %Order{}} = OrderDomain.add_line_item(%Order{state: "cart"}, nil)
+    end
+  end
+
+  describe "update_line_item/2" do
+    test "when order.state is `cart`" do
+      assert {:ok, %Order{}} = OrderDomain.update_line_item(%Order{state: "cart"}, nil)
+    end
+  end
+
+  describe "remove_line_item/2" do
+    test "when order.state is `cart`" do
+      assert {:ok, %Order{}} = OrderDomain.remove_line_item(%Order{state: "cart"}, nil)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation
Pivotal stories: [#158605670](https://www.pivotaltracker.com/story/show/158605670), [#158605689](https://www.pivotaltracker.com/story/show/158605689), [#158606851](https://www.pivotaltracker.com/story/show/158606851)

Snitch lacked a `LineItem` CRUD API because we wanted to operate on the whole association via the `Order` changeset. The typical use-case is far from this, where we need to operate on a single line item, and not a bunch of them.
This new API makes implementation of a line item `resource` trivial.
**It is still possible to operate on a bunch of line items, but only via an `order` changeset in the boundaries defined by `cast_assoc`.**

Thus, the order controller can accept requests to edit its `relationship`s (see [JSONAPI](http://jsonapi.org/format/#crud-updating-relationships)) via `Model.Order`, and the line item controller can allow the typical CRUD via `Model.LineItem`.

## Description
Introduces the `OrderDomain` (finally?!) and `create`, `update` and `delete` in `Model.LineItem`.

## Gotchas :shield: 
Before you attack me with the thing about order totals, look [here](https://hackmd.io/4Neif6WUQIGSftYPpiMMTw?view) at the definitions of the `cart` and `address` states.

------
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
