### PR TITLE
 Remove the line_item.total field

### DIFF
--- a/apps/admin_app/lib/admin_app_web/views/order_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/order_view.ex
@@ -37,7 +37,7 @@ defmodule AdminAppWeb.OrderView do
       render_variant(line_item.variant),
       content_tag(:td, line_item.unit_price),
       render_quantity_with_stock(line_item),
-      content_tag(:td, line_item.total),
+      content_tag(:td, Money.mult!(line_item.unit_price, line_item.quantity)),
       render_buttons(state)
     ]
 

--- a/apps/snitch_api/lib/snitch_api_web/views/line_item_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/line_item_view.ex
@@ -4,5 +4,5 @@ defmodule SnitchApiWeb.LineItemView do
 
   location("/line_items/:id")
 
-  attributes([:id, :quantity, :unit_price, :total])
+  attributes([:id, :variant_id, :quantity, :unit_price])
 end

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -135,6 +135,6 @@ defmodule Snitch.Data.Model.Order do
   def get_all, do: Repo.all(Order)
 
   defp update_line_item_costs(line_items) when is_list(line_items) do
-    LineItemModel.update_price_and_totals(line_items)
+    LineItemModel.update_unit_price(line_items)
   end
 end

--- a/apps/snitch_core/lib/core/data/model/variant.ex
+++ b/apps/snitch_core/lib/core/data/model/variant.ex
@@ -3,10 +3,22 @@ defmodule Snitch.Data.Model.Variant do
   Variant API
   """
   use Snitch.Data.Model
+
   alias Snitch.Data.Schema.Variant
 
   def get_category(%Variant{} = v) do
     variant = Repo.preload(v, :shipping_category)
     variant.shipping_category
+  end
+
+  def get_selling_prices(variant_ids) do
+    # TODO: change the source of selling price to the something else.
+    query = from(v in Variant, select: {v.id, v.selling_price}, where: v.id in ^variant_ids)
+
+    query
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {v_id, sp}, acc ->
+      Map.put(acc, v_id, sp)
+    end)
   end
 end

--- a/apps/snitch_core/lib/core/data/model/variant.ex
+++ b/apps/snitch_core/lib/core/data/model/variant.ex
@@ -6,11 +6,6 @@ defmodule Snitch.Data.Model.Variant do
 
   alias Snitch.Data.Schema.Variant
 
-  def get_category(%Variant{} = v) do
-    variant = Repo.preload(v, :shipping_category)
-    variant.shipping_category
-  end
-
   def get_selling_prices(variant_ids) do
     # TODO: change the source of selling price to the something else.
     query = from(v in Variant, select: {v.id, v.selling_price}, where: v.id in ^variant_ids)

--- a/apps/snitch_core/lib/core/data/schema/line_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/line_item.ex
@@ -12,15 +12,14 @@ defmodule Snitch.Data.Schema.LineItem do
   schema "snitch_line_items" do
     field(:quantity, :integer)
     field(:unit_price, Money.Ecto.Composite.Type)
-    field(:total, Money.Ecto.Composite.Type)
 
     belongs_to(:variant, Variant)
     belongs_to(:order, Order)
     timestamps()
   end
 
-  @cast_fields ~w(quantity variant_id unit_price total)a
-  @update_fields ~w(quantity unit_price total)a
+  @cast_fields ~w(quantity variant_id unit_price)a
+  @update_fields ~w(quantity unit_price)a
   @create_fields [:order_id | @cast_fields]
 
   @doc """
@@ -56,7 +55,6 @@ defmodule Snitch.Data.Schema.LineItem do
   def update_changeset(%__MODULE__{} = line_item, params) do
     line_item
     |> cast(params, @update_fields)
-    |> validate_conditional_required()
     |> common_changeset()
   end
 
@@ -64,15 +62,5 @@ defmodule Snitch.Data.Schema.LineItem do
     changeset
     |> validate_number(:quantity, greater_than: 0)
     |> validate_amount(:unit_price)
-    |> validate_amount(:total)
-  end
-
-  defp validate_conditional_required(%{changes: changes} = changeset) do
-    if (Map.has_key?(changes, :quantity) or Map.has_key?(changes, :unit_price)) and
-         not Map.has_key?(changes, :total) do
-      add_error(changeset, :total, "can't be blank", validation: :required)
-    else
-      changeset
-    end
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/variant.ex
+++ b/apps/snitch_core/lib/core/data/schema/variant.ex
@@ -4,11 +4,9 @@ defmodule Snitch.Data.Schema.Variant do
   """
 
   use Snitch.Data.Schema
-  import Ecto.Query
 
   alias Money.Ecto.Composite.Type, as: MoneyType
   alias Snitch.Data.Schema.{ShippingCategory, StockItem}
-  alias Snitch.Repo
 
   @type t :: %__MODULE__{}
 
@@ -52,18 +50,5 @@ defmodule Snitch.Data.Schema.Variant do
     #
     # Variants has_one shipping category through Products, so we won't be
     # placing a FK constraint here.
-  end
-
-  def get_selling_prices(variant_ids) do
-    # TODO: move the function to variant model
-    query =
-      from(v in "snitch_variants", select: [v.id, v.selling_price], where: v.id in ^variant_ids)
-
-    query
-    |> Repo.all()
-    |> Enum.reduce(%{}, fn [v_id, sp], acc ->
-      {:ok, cost} = MoneyType.load(sp)
-      Map.put(acc, v_id, cost)
-    end)
   end
 end

--- a/apps/snitch_core/lib/core/domain/calculator/default_tax_calculator.ex
+++ b/apps/snitch_core/lib/core/domain/calculator/default_tax_calculator.ex
@@ -6,13 +6,15 @@ defmodule Snitch.Domain.Calculator.Default do
 
   alias Snitch.Data.Schema.LineItem
 
-  def compute(tax_rate, %LineItem{} = lineitem) do
+  def compute(tax_rate, %LineItem{} = line_item) do
+    total = Money.mult!(line_item.unit_price, line_item.quantity)
+
     {:ok, value} =
       if tax_rate.included_in_price do
-        {:ok, offset} = Money.div(lineitem.total, 1 + tax_rate.value)
-        Money.sub(lineitem.total, offset)
+        {:ok, offset} = Money.div(total, 1 + tax_rate.value)
+        Money.sub(total, offset)
       else
-        Money.mult(lineitem.total, tax_rate.value)
+        Money.mult(total, tax_rate.value)
       end
 
     value

--- a/apps/snitch_core/lib/core/tools/helpers/order.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/order.ex
@@ -8,7 +8,6 @@ defmodule Snitch.Tools.Helper.Order do
   @line_item %{
     quantity: nil,
     unit_price: nil,
-    total: nil,
     variant_id: nil,
     order_id: nil,
     inserted_at: DateTime.utc(),
@@ -96,8 +95,7 @@ defmodule Snitch.Tools.Helper.Order do
         | quantity: q,
           variant_id: v.id,
           order_id: order_id,
-          unit_price: v.selling_price,
-          total: Money.mult!(v.selling_price, q)
+          unit_price: v.selling_price
       }
     end)
   end

--- a/apps/snitch_core/priv/repo/migrations/20180705161335_remove_line_item_total_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180705161335_remove_line_item_total_field.exs
@@ -1,0 +1,15 @@
+defmodule Snitch.Repo.Migrations.RemoveLineItemTotalField do
+  use Ecto.Migration
+
+  def up do
+    alter table("snitch_line_items") do
+      remove :total
+    end
+  end
+
+  def down do
+    alter table("snitch_line_items") do
+      add :total, :money_with_currency, null: false
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/orders.ex
+++ b/apps/snitch_core/priv/repo/seed/orders.ex
@@ -82,7 +82,9 @@ defmodule Snitch.Seed.Orders do
 
       item_total =
         line_items
-        |> Stream.map(&Map.fetch!(&1, :total))
+        |> Stream.map(fn %{unit_price: price, quantity: q} ->
+          Money.mult!(price, q)
+        end)
         |> Enum.reduce(&Money.add!/2)
 
       order = %{

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -11,15 +11,15 @@ defmodule Snitch.Data.Model.LineItemTest do
     setup :variants
     setup :good_line_items
 
-    test "update_price_and_totals/1", context do
-      %{line_items: line_items, totals: totals} = context
-      priced_items = LineItem.update_price_and_totals(line_items)
-      assert Enum.all?(priced_items, fn x -> totals[x.variant_id] == Money.reduce(x.total) end)
+    test "update_unit_price/1", context do
+      %{line_items: line_items} = context
+      priced_items = LineItem.update_unit_price(line_items)
+      assert Enum.all?(priced_items, fn %{unit_price: price} -> not is_nil(price) end)
     end
 
-    test "compute_totals/1", context do
+    test "compute_total/1", context do
       %{line_items: line_items} = context
-      priced_items = LineItem.update_price_and_totals(line_items)
+      priced_items = LineItem.update_unit_price(line_items)
       assert %Money{} = LineItem.compute_total(priced_items)
     end
   end
@@ -28,12 +28,14 @@ defmodule Snitch.Data.Model.LineItemTest do
     setup :variants
     setup :bad_line_items
 
-    test "update_price_and_totals/1", context do
-      %{line_items: line_items} = context
-      priced_items = LineItem.update_price_and_totals(line_items)
+    test "update_unit_price/1", %{line_items: line_items} do
+      priced_items = LineItem.update_unit_price(line_items)
 
-      assert Enum.all?(priced_items, &(not Map.has_key?(&1, :total)))
-      assert Enum.all?(priced_items, &(not Map.has_key?(&1, :unit_price)))
+      assert [
+               %{quantity: 2, variant_id: -1},
+               %{quantity: nil, unit_price: %Money{}, variant_id: _},
+               %{quantity: 2, variant_id: nil}
+             ] = priced_items
     end
   end
 
@@ -106,31 +108,13 @@ defmodule Snitch.Data.Model.LineItemTest do
     setup :user_with_address
 
     @tag variant_count: 1
-    test "fails with invalid params", %{variants: [v], user: user} do
-      order = insert(:order, user: user)
-      order = struct(order, line_items(%{order: order, variants: [v]}))
-
-      [li] = order.line_items
-
-      params = %{
-        quantity: li.quantity + 1
-      }
-
-      {:error, :line_item, cs, %{}} = LineItem.update(li, params)
-      assert %{total: ["can't be blank"]} = errors_on(cs)
-    end
-
-    @tag variant_count: 1
     test "with valid params", %{variants: [v], user: user} do
       order = insert(:order, user: user)
       order = struct(order, line_items(%{order: order, variants: [v]}))
 
       [li] = order.line_items
 
-      params = %{
-        quantity: li.quantity + 1,
-        total: Money.add!(li.total, li.unit_price)
-      }
+      params = %{quantity: li.quantity + 1}
 
       {:ok, li} = LineItem.update(li, params)
       assert Ecto.assoc_loaded?(li.order)
@@ -157,62 +141,18 @@ defmodule Snitch.Data.Model.LineItemTest do
     end
   end
 
-  describe "create/1 for order in `address` state" do
-    setup :variants
-    setup :user_with_address
-
-    @tag :skip
-    @tag variant_count: 1
-    test "which is empty", %{variants: [v], user: user} do
-      order = insert(:order, line_items: [], user: user)
-
-      {:ok, li} = LineItem.create(%{line_item_params(v) | order_id: order.id})
-      assert Ecto.assoc_loaded?(li.order)
-      assert Ecto.assoc_loaded?(li.order.line_items)
-      assert length(li.order.line_items) == 1
-      assert order.item_total == li.total
-      assert order.total == li.total
-    end
-
-    @tag :skip
-    @tag variant_count: 2
-    test "with existing line_items", %{variants: [v1, v2], user: user} do
-      order =
-        insert(
-          :order,
-          item_total: v1.selling_price,
-          total: v1.selling_price,
-          user: user,
-          state: "address"
-        )
-
-      order = struct(order, line_items(%{order: order, variants: [v1]}))
-
-      assert length(order.line_items) == 1
-      [li] = order.line_items
-      assert li.variant_id == v1.id
-
-      {:ok, li} = LineItem.create(%{line_item_params(v2) | order_id: order.id})
-      assert Money.reduce(li.order.item_total) == Money.add!(li.total, v1.selling_price)
-      assert Money.reduce(li.order.total) == Money.add!(li.total, v1.selling_price)
-    end
-  end
-
   defp good_line_items(context) do
     %{variants: vs} = context
     quantities = Stream.cycle([2])
 
-    {line_items, totals} =
+    line_items =
       vs
       |> Stream.zip(quantities)
-      |> Enum.reduce({[], %{}}, fn {variant, quantity}, {ls, ts} ->
-        {
-          [%{variant_id: variant.id, quantity: quantity} | ls],
-          Map.put(ts, variant.id, Money.mult!(variant.selling_price, quantity))
-        }
+      |> Enum.reduce([], fn {variant, quantity}, acc ->
+        [%{variant_id: variant.id, quantity: quantity} | acc]
       end)
 
-    [line_items: line_items, totals: totals]
+    [line_items: line_items]
   end
 
   defp bad_line_items(context) do

--- a/apps/snitch_core/test/data/model/variant_test.exs
+++ b/apps/snitch_core/test/data/model/variant_test.exs
@@ -1,0 +1,34 @@
+defmodule Snitch.Data.Model.VariantTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Model.Variant
+
+  test "get_category/1" do
+    v = insert(:variant, shipping_category: build(:shipping_category))
+    assert v.shipping_category == Variant.get_category(v)
+  end
+
+  describe "get_selling_prices/1" do
+    setup :variants
+
+    test "with valid and invalid ids", %{variants: vs} do
+      ids = Enum.map(vs, fn %{id: id} -> id end)
+
+      prices = Variant.get_selling_prices([-1 | ids])
+
+      assert Enum.into(prices, %{}, fn {v_id, money} ->
+               {v_id, Money.reduce(money)}
+             end) ==
+               Enum.into(vs, %{}, fn %{id: id, selling_price: sp} ->
+                 {id, sp}
+               end)
+    end
+
+    test "with empty list" do
+      assert %{} == Variant.get_selling_prices([])
+    end
+  end
+end

--- a/apps/snitch_core/test/data/model/variant_test.exs
+++ b/apps/snitch_core/test/data/model/variant_test.exs
@@ -6,11 +6,6 @@ defmodule Snitch.Data.Model.VariantTest do
 
   alias Snitch.Data.Model.Variant
 
-  test "get_category/1" do
-    v = insert(:variant, shipping_category: build(:shipping_category))
-    assert v.shipping_category == Variant.get_category(v)
-  end
-
   describe "get_selling_prices/1" do
     setup :variants
 

--- a/apps/snitch_core/test/data/schema/line_item_test.exs
+++ b/apps/snitch_core/test/data/schema/line_item_test.exs
@@ -12,8 +12,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
     order_id: nil,
     variant_id: nil,
     quantity: 1,
-    unit_price: nil,
-    total: nil
+    unit_price: nil
   }
 
   setup :variants
@@ -34,7 +33,6 @@ defmodule Snitch.Data.Schema.LineItemTest do
       assert %{
                order_id: ["can't be blank"],
                quantity: ["can't be blank"],
-               total: ["can't be blank"],
                unit_price: ["can't be blank"],
                variant_id: ["can't be blank"]
              } = errors_on(cs)
@@ -48,10 +46,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
             order_id: order.id
         })
 
-      assert %{
-               total: ["can't be blank"],
-               unit_price: ["can't be blank"]
-             } = errors_on(cs)
+      assert %{unit_price: ["can't be blank"]} = errors_on(cs)
     end
 
     test "fails with bad price fields", %{order: order, variants: [variant | _]} do
@@ -60,14 +55,10 @@ defmodule Snitch.Data.Schema.LineItemTest do
           @params
           | variant_id: variant.id,
             order_id: order.id,
-            unit_price: Money.new(-1, :USD),
-            total: Money.new(-2, :USD)
+            unit_price: Money.new(-1, :USD)
         })
 
-      assert %{
-               total: ["must be equal or greater than 0"],
-               unit_price: ["must be equal or greater than 0"]
-             } = errors_on(cs)
+      assert %{unit_price: ["must be equal or greater than 0"]} = errors_on(cs)
     end
 
     test "with price fields", %{order: order, variants: [variant | _]} do
@@ -76,14 +67,13 @@ defmodule Snitch.Data.Schema.LineItemTest do
           @params
           | variant_id: variant.id,
             order_id: order.id,
-            unit_price: Money.new(0, :USD),
-            total: Money.new(0, :USD)
+            unit_price: Money.new(0, :USD)
         })
 
       assert cs.valid?
 
       [params_with_price] =
-        LineItemModel.update_price_and_totals([
+        LineItemModel.update_unit_price([
           %{@params | variant_id: variant.id, order_id: order.id}
         ])
 
@@ -99,25 +89,10 @@ defmodule Snitch.Data.Schema.LineItemTest do
           @params
           | variant_id: variant.id,
             order_id: order.id,
-            unit_price: Money.new(2, :USD),
-            total: Money.new(2, :USD)
+            unit_price: Money.new(2, :USD)
         })
 
       [line_item: Changeset.apply_changes(cs)]
-    end
-
-    test "fails with only quantity", %{line_item: line_item} do
-      cs = LineItem.update_changeset(line_item, %{quantity: line_item.quantity + 1})
-      refute cs.valid?
-      assert %{total: ["can't be blank"]} = errors_on(cs)
-    end
-
-    test "fails with only unit_price", %{line_item: line_item} do
-      cs =
-        LineItem.update_changeset(line_item, %{unit_price: Money.mult!(line_item.unit_price, 2)})
-
-      refute cs.valid?
-      assert %{total: ["can't be blank"]} = errors_on(cs)
     end
 
     test "with empty params", %{line_item: line_item} do
@@ -130,12 +105,15 @@ defmodule Snitch.Data.Schema.LineItemTest do
         LineItem.update_changeset(line_item, %{
           @params
           | variant_id: 1,
-            unit_price: Money.new(2, :USD),
-            total: Money.new(2, :USD)
+            unit_price: Money.new(2, :USD)
         })
 
       assert cs.valid?
       refute Map.has_key?(cs.changes, :variant_id)
+
+      cs = LineItem.update_changeset(line_item, %{quantity: 5})
+      assert cs.valid?
+      assert %{quantity: 5} == cs.changes
     end
   end
 end

--- a/apps/snitch_core/test/domain/calculator/default_calculator_test.exs
+++ b/apps/snitch_core/test/domain/calculator/default_calculator_test.exs
@@ -14,8 +14,7 @@ defmodule Snitch.Domain.DefaultCalculatorTest do
     order_id: 1,
     variant_id: 1,
     quantity: 1,
-    unit_price: Money.new("15.00", :USD),
-    total: Money.new("15.00", :USD)
+    unit_price: Money.new("15.00", :USD)
   }
 
   describe "compute/2" do

--- a/apps/snitch_core/test/domain/order/order_test.exs
+++ b/apps/snitch_core/test/domain/order/order_test.exs
@@ -60,9 +60,11 @@ defmodule Snitch.Domain.OrderTest do
         |> Order.partial_update_changeset(%{})
         |> OrderDomain.compute_taxes_changeset()
 
+      total = Money.mult!(item.unit_price, item.quantity)
+
       assert %{
-               item_total: item.total,
-               total: item.total,
+               item_total: total,
+               total: total,
                tax_total: Money.zero(:USD)
              } == cs.changes
 

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -66,8 +66,7 @@ defmodule Snitch.Factory do
       order: build(:order),
       variant: build(:variant),
       quantity: 2,
-      unit_price: Money.new("9.99", currency()),
-      total: Money.new("19.98", currency())
+      unit_price: Money.new("9.99", currency())
     }
   end
 
@@ -183,8 +182,7 @@ defmodule Snitch.Factory do
           order_id: order.id,
           variant_id: v.id,
           quantity: 1,
-          unit_price: v.selling_price,
-          total: v.selling_price
+          unit_price: v.selling_price
         )
       end)
       |> Enum.take(count)


### PR DESCRIPTION
## Motivation
We must remove fields that simply "cache" computations from the DB. They
rarely help (optimization-wise) but become a huge PITA when we update
the "operands" of said computation -- the update must cascade to these
cache fields as well.

## Description
This change gets rid of `line_item.total` field.

* Compute the total inline in all places that required this field.
* Added tests for `Model.Variant`.
* Updated the views in `snitch_api` and `admin_app`

Migrations
----------
Remove `:total` from `LineItem`.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
