### PR TITLE
 Remove the order.*_total, order.total fields

### DIFF
--- a/apps/admin_app/lib/admin_app_web/views/order_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/order_view.ex
@@ -4,6 +4,8 @@ defmodule AdminAppWeb.OrderView do
 
   alias Snitch.Data.Model.Order, as: OrderModel
 
+  alias Snitch.Data.Model.LineItem
+
   @bootstrap_contextual_class %{
     "cart" => "light",
     "address" => "light",
@@ -15,7 +17,7 @@ defmodule AdminAppWeb.OrderView do
     "completed" => "success"
   }
 
-  @summary_fields ~w(item_total adjustment_total promo_total total)a
+  @summary_fields ~w(item_total tax_total adjustment_total promo_total total)a
   @summary_fields_capitalized Enum.map(@summary_fields, fn field ->
                                 field
                                 |> Atom.to_string()
@@ -104,12 +106,23 @@ defmodule AdminAppWeb.OrderView do
     )
   end
 
+  defp make_summary_row({field, field_capitalized}, order) when field in ~w(item_total total)a do
+    content_tag(
+      :tr,
+      [
+        content_tag(:th, field_capitalized, scope: "row"),
+        content_tag(:td, LineItem.compute_total(order.line_items))
+      ],
+      class: Map.get(@summary_field_classes, field)
+    )
+  end
+
   defp make_summary_row({field, field_capitalized}, order) do
     content_tag(
       :tr,
       [
         content_tag(:th, field_capitalized, scope: "row"),
-        content_tag(:td, Map.fetch!(order, field))
+        content_tag(:td, Snitch.Tools.Money.zero!())
       ],
       class: Map.get(@summary_field_classes, field)
     )

--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -34,7 +34,7 @@ defmodule SnitchApiWeb.OrderController do
   end
 
   def guest_order(conn, _params) do
-    with {:ok, %Order{} = order} <- OrderModel.create_guest_order() do
+    with {:ok, %Order{} = order} <- OrderModel.create_for_guest(%{}) do
       conn
       |> put_status(200)
       |> put_resp_header("location", order_path(conn, :show, order))

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -33,9 +33,31 @@ defmodule Snitch.Data.Model.Order do
     QH.create(Order, update_in(params, [:line_items], &update_line_item_costs/1), Repo)
   end
 
-  def create_guest_order() do
+  @doc """
+  Creates an order with supplied `params` and `line_items`.
+
+  Suitable for creating orders for guest users. The `order.user_id` cannot be
+  set using this function.
+
+  > * `line_items` is not a list of `LineItem` schema structs, but just a list
+  >   of maps with the keys `:variant_id` and `:quantity`.
+  > * These `LineItem`s will be created (casted, to be precise) along with the
+  >   `Order` in a DB transaction.
+
+  ## Example
+  ```
+  line_items = [%{variant_id: 1, quantity: 42}, %{variant_id: 2, quantity: 42}]
+  params = %{user_id: 1}
+  {:ok, order} = Snitch.Data.Model.Order.create(params, line_items)
+  ```
+
+  ## See also
+  `Ecto.Changeset.cast_assoc/3`
+  """
+  @spec create_for_guest(map) :: {:ok, Order.t()} | {:error, Ecto.Changeset.t()}
+  def create_for_guest(params) do
     %Order{}
-    |> Order.create_guest_changeset(%{})
+    |> Order.create_for_guest_changeset(params)
     |> Repo.insert()
   end
 

--- a/apps/snitch_core/lib/core/data/schema/order.ex
+++ b/apps/snitch_core/lib/core/data/schema/order.ex
@@ -15,12 +15,6 @@ defmodule Snitch.Data.Schema.Order do
     field(:state, :string, default: "cart")
     field(:special_instructions, :string)
 
-    # various prices and totals
-    field(:total, Money.Ecto.Composite.Type)
-    field(:item_total, Money.Ecto.Composite.Type)
-    field(:adjustment_total, Money.Ecto.Composite.Type)
-    field(:promo_total, Money.Ecto.Composite.Type)
-
     embeds_one(:billing_address, OrderAddress, on_replace: :update)
     embeds_one(:shipping_address, OrderAddress, on_replace: :update)
 
@@ -33,18 +27,17 @@ defmodule Snitch.Data.Schema.Order do
   end
 
   @required_fields ~w(state user_id)a
-  @money_fields ~w(item_total promo_total adjustment_total total)a
+  @create_fields @required_fields
 
-  @create_fields @required_fields ++ @money_fields
-  @update_fields ~w(state special_instructions)a ++ @money_fields
+  @update_fields ~w(state special_instructions)a
   @partial_update_fields @update_fields
 
   @doc """
-  Returns a Order changeset with totals for a "new" order.
+  Returns a Order changeset for a "new" order.
 
   A list of `LineItem` params can be provided under the `:line_items` key, and
   each of those must include price fields, use
-  `Snitch.Data.Model.LineItem.update_price_and_totals/1` if needed.
+  `Snitch.Data.Model.LineItem.update_unit_price/1` if needed.
   > Note that `variant_id`s must be unique in each line item.
   """
   @spec create_changeset(t, map) :: Ecto.Changeset.t()
@@ -56,11 +49,10 @@ defmodule Snitch.Data.Schema.Order do
     |> foreign_key_constraint(:user_id)
     |> cast_assoc(:line_items)
     |> ensure_unique_line_items()
-    |> common_changeset()
   end
 
   @doc """
-  Returns a Order changeset with totals to update `order`.
+  Returns a Order changeset to update `order`.
 
   `LineItem` params (if any) must include price fields.
   > Note that `variant_id`s must be unique in each line item.
@@ -71,7 +63,6 @@ defmodule Snitch.Data.Schema.Order do
     |> cast(params, @update_fields)
     |> cast_assoc(:line_items)
     |> ensure_unique_line_items()
-    |> common_changeset()
   end
 
   @spec create_guest_changeset(t, map) :: Ecto.Changeset.t()
@@ -94,15 +85,6 @@ defmodule Snitch.Data.Schema.Order do
     |> cast(params, @partial_update_fields)
     |> cast_embed(:billing_address)
     |> cast_embed(:shipping_address)
-  end
-
-  @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
-  defp common_changeset(order_changeset) do
-    order_changeset
-    |> validate_amount(:item_total)
-    |> validate_amount(:promo_total)
-    |> validate_amount(:adjustment_total)
-    |> validate_amount(:total)
   end
 
   @spec ensure_unique_line_items(Ecto.Changeset.t()) :: Ecto.Changeset.t()

--- a/apps/snitch_core/lib/core/data/schema/order.ex
+++ b/apps/snitch_core/lib/core/data/schema/order.ex
@@ -65,12 +65,24 @@ defmodule Snitch.Data.Schema.Order do
     |> ensure_unique_line_items()
   end
 
-  @spec create_guest_changeset(t, map) :: Ecto.Changeset.t()
-  def create_guest_changeset(%__MODULE__{} = order, params) do
+  @doc """
+  Returns a Order changeset for a "new" order without a user.
+
+  A list of `LineItem` params can be provided under the `:line_items` key, and
+  each of those must include price fields, use
+  `Snitch.Data.Model.LineItem.update_unit_price/1` if needed.
+  > Note that `variant_id`s must be unique in each line item.
+
+  Suitable for creating orders for guest users.
+  """
+  @spec create_for_guest_changeset(t, map) :: Ecto.Changeset.t()
+  def create_for_guest_changeset(%__MODULE__{} = order, params) do
     order
-    |> cast(params, [])
+    |> cast(params, [:state])
+    |> validate_required([:state])
     |> unique_constraint(:number)
-    |> common_changeset()
+    |> cast_assoc(:line_items)
+    |> ensure_unique_line_items()
   end
 
   @doc """

--- a/apps/snitch_core/priv/repo/migrations/20180705190618_remove_order_total_fields.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180705190618_remove_order_total_fields.exs
@@ -1,0 +1,21 @@
+defmodule Snitch.Repo.Migrations.RemoveOrderTotalFields do
+  use Ecto.Migration
+
+  def up do
+    alter table("snitch_orders") do
+      remove :total
+      remove :item_total
+      remove :promo_total
+      remove :adjustment_total
+    end
+  end
+  
+  def down do
+    alter table("snitch_orders") do
+      add :total, :money_with_currency
+      add :item_total, :money_with_currency
+      add :promo_total, :money_with_currency
+      add :adjustment_total, :money_with_currency
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/orders.ex
+++ b/apps/snitch_core/priv/repo/seed/orders.ex
@@ -15,10 +15,6 @@ defmodule Snitch.Seed.Orders do
     user_id: nil,
     billing_address: nil,
     shipping_address: nil,
-    adjustment_total: nil,
-    promo_total: nil,
-    item_total: nil,
-    total: nil,
     inserted_at: DateTime.utc(),
     updated_at: DateTime.utc()
   }
@@ -80,22 +76,13 @@ defmodule Snitch.Seed.Orders do
       number = "#{Nanoid.generate()}-#{index}"
       line_items = line_items_with_price(variants, manifest.quantity)
 
-      item_total =
-        line_items
-        |> Stream.map(fn %{unit_price: price, quantity: q} ->
-          Money.mult!(price, q)
-        end)
-        |> Enum.reduce(&Money.add!/2)
-
       order = %{
         @order
         | number: number,
           state: "#{manifest.state}",
           user_id: manifest[:user_id],
           billing_address: manifest[:address],
-          shipping_address: manifest[:address],
-          item_total: item_total,
-          total: item_total
+          shipping_address: manifest[:address]
       }
 
       {order, line_items}

--- a/apps/snitch_core/priv/repo/seed/roles_seed.ex
+++ b/apps/snitch_core/priv/repo/seed/roles_seed.ex
@@ -18,6 +18,6 @@ defmodule Snitch.Seed.Role do
         [value | acc]
       end)
 
-    Repo.insert_all(Role, data)
+    Repo.insert_all(Role, data, on_conflict: :nothing, conflict_target: :name)
   end
 end

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -58,7 +58,6 @@ defmodule Snitch.Data.Model.LineItemTest do
 
   describe "create/1" do
     setup :variants
-    setup :user_with_address
 
     @tag variant_count: 1
     test "fails without an existing order", %{variants: [v]} do
@@ -75,11 +74,11 @@ defmodule Snitch.Data.Model.LineItemTest do
 
   describe "create/1 for order in `cart` state" do
     setup :variants
-    setup :user_with_address
+    setup :orders
 
     @tag variant_count: 1
-    test "which is empty", %{variants: [v], user: user} do
-      order = insert(:order, line_items: [], user: user)
+    test "which is empty", %{variants: [v], orders: [order]} do
+      order = struct(order, line_items: [])
 
       {:ok, li} = LineItem.create(%{line_item_params(v) | order_id: order.id})
       assert Ecto.assoc_loaded?(li.order)
@@ -88,8 +87,7 @@ defmodule Snitch.Data.Model.LineItemTest do
     end
 
     @tag variant_count: 2
-    test "with existing line_items", %{variants: [v1, v2], user: user} do
-      order = insert(:order, user: user)
+    test "with existing line_items", %{variants: [v1, v2], orders: [order]} do
       order = struct(order, line_items(%{order: order, variants: [v1]}))
 
       assert length(order.line_items) == 1
@@ -105,11 +103,10 @@ defmodule Snitch.Data.Model.LineItemTest do
 
   describe "update/1 for order in `cart` state" do
     setup :variants
-    setup :user_with_address
+    setup :orders
 
     @tag variant_count: 1
-    test "with valid params", %{variants: [v], user: user} do
-      order = insert(:order, user: user)
+    test "with valid params", %{variants: [v], orders: [order]} do
       order = struct(order, line_items(%{order: order, variants: [v]}))
 
       [li] = order.line_items
@@ -125,11 +122,10 @@ defmodule Snitch.Data.Model.LineItemTest do
 
   describe "delete/1 for order in `cart` state" do
     setup :variants
-    setup :user_with_address
+    setup :orders
 
     @tag variant_count: 1
-    test "with valid params", %{variants: [v], user: user} do
-      order = insert(:order, user: user)
+    test "with valid params", %{variants: [v], orders: [order]} do
       order = struct(order, line_items(%{order: order, variants: [v]}))
 
       [line_item] = order.line_items

--- a/apps/snitch_core/test/data/model/order_test.exs
+++ b/apps/snitch_core/test/data/model/order_test.exs
@@ -27,6 +27,22 @@ defmodule Snitch.Data.Model.OrderTest do
     end
   end
 
+  describe "create_for_guest/3" do
+    test "with valid data", %{order_params: params, variants: vs} do
+      {:ok, order} = Order.create(params)
+      assert length(order.line_items) == length(vs)
+    end
+
+    test "without line_items", %{order_params: params} do
+      {:ok, order} =
+        params
+        |> Map.put(:line_items, [])
+        |> Order.create()
+
+      assert [] = order.line_items
+    end
+  end
+
   describe "update/3" do
     test "add some line_items", %{order_params: order_params} do
       {:ok, order} = Order.create(order_params)

--- a/apps/snitch_core/test/data/model/order_test.exs
+++ b/apps/snitch_core/test/data/model/order_test.exs
@@ -12,21 +12,18 @@ defmodule Snitch.Data.Model.OrderTest do
   setup :order_params
 
   describe "create/3" do
-    test "with valid data", %{order_params: params} do
+    test "with valid data", %{order_params: params, variants: vs} do
       {:ok, order} = Order.create(params)
-      assert order.item_total == LineItem.compute_total(params.line_items)
-      assert order.total == LineItem.compute_total(params.line_items)
+      assert length(order.line_items) == length(vs)
     end
 
     test "without line_items", %{order_params: params} do
       {:ok, order} =
         params
         |> Map.put(:line_items, [])
-        |> Map.drop([:item_total, :total])
         |> Order.create()
 
-      assert order.item_total == nil
-      assert order.total == nil
+      assert [] = order.line_items
     end
   end
 
@@ -37,49 +34,33 @@ defmodule Snitch.Data.Model.OrderTest do
       old_line_items = extract_ids(order.line_items)
       line_items = [%{variant_id: new_variant.id, quantity: 1} | old_line_items]
 
-      {:ok, %{line_items: new_items} = new_order} = Order.update(%{line_items: line_items}, order)
+      {:ok, %{line_items: new_items}} = Order.update(%{line_items: line_items}, order)
       assert Enum.count(new_items) == 4
       assert Enum.all?(old_line_items, fn x -> x in extract_ids(new_items) end)
-      assert order.item_total == new_order.item_total
-      assert order.total == new_order.total
     end
 
     test "remove some line_items", %{order_params: order_params} do
       {:ok, order} = Order.create(order_params)
 
       [line_item | _] = order.line_items
-      total = Money.mult!(line_item.unit_price, line_item.quantity)
 
-      {:ok, %{line_items: new_items} = new_order} =
+      {:ok, %{line_items: new_items}} =
         Order.update(
-          %{
-            line_items: [%{id: line_item.id}],
-            item_total: total,
-            total: total
-          },
+          %{line_items: [%{id: line_item.id}]},
           order
         )
 
       assert Enum.count(new_items) == 1
-      assert new_order.item_total == total
-      assert new_order.total == total
     end
 
     test "remove all line_items", %{order_params: order_params} do
       {:ok, order} = Order.create(order_params)
 
-      assert {:ok, %{line_items: []} = new_order} =
+      assert {:ok, %{line_items: []}} =
                Order.update(
-                 %{
-                   line_items: [],
-                   item_total: Money.zero(:USD),
-                   total: Money.zero(:USD)
-                 },
+                 %{line_items: []},
                  order
                )
-
-      assert new_order.item_total == Money.zero(:USD)
-      assert new_order.total == Money.zero(:USD)
     end
 
     test "update few items", %{order_params: order_params} do
@@ -136,9 +117,7 @@ defmodule Snitch.Data.Model.OrderTest do
       order_params: %{
         user_id: user.id,
         number: "long_unique_number",
-        line_items: li,
-        item_total: LineItem.compute_total(li),
-        total: LineItem.compute_total(li)
+        line_items: li
       }
     ]
   end

--- a/apps/snitch_core/test/data/model/package_item_test.exs
+++ b/apps/snitch_core/test/data/model/package_item_test.exs
@@ -4,8 +4,10 @@ defmodule Snitch.Data.Model.PackageItemTest do
   import Snitch.Factory
   alias Snitch.Data.Model.PackageItem
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [order: insert(:order)]
+  end
+
   setup :variants
   setup :line_items
   setup :shipping_categories

--- a/apps/snitch_core/test/data/model/package_test.exs
+++ b/apps/snitch_core/test/data/model/package_test.exs
@@ -7,8 +7,10 @@ defmodule Snitch.Data.Model.PackageTest do
   alias Snitch.Data.Model.Package
   alias Snitch.Data.Schema.ShippingMethod
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [order: insert(:order)]
+  end
+
   setup :variants
   setup :line_items
   setup :shipping_categories

--- a/apps/snitch_core/test/data/model/payment/card_payment_test.exs
+++ b/apps/snitch_core/test/data/model/payment/card_payment_test.exs
@@ -6,8 +6,13 @@ defmodule Snitch.Data.Model.CardPaymentTest do
 
   alias Snitch.Data.Model.CardPayment
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [
+      user: insert(:user),
+      order: insert(:order)
+    ]
+  end
+
   setup :payment_methods
   setup :cards
   setup :card_payment

--- a/apps/snitch_core/test/data/model/payment/payment_test.exs
+++ b/apps/snitch_core/test/data/model/payment/payment_test.exs
@@ -7,8 +7,12 @@ defmodule Snitch.Data.Model.PaymentTest do
   alias Snitch.Data.Model
   alias Snitch.Data.Schema
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [
+      order: insert(:order)
+    ]
+  end
+
   setup :payment_methods
   setup :payments
 

--- a/apps/snitch_core/test/data/schema/line_item_test.exs
+++ b/apps/snitch_core/test/data/schema/line_item_test.exs
@@ -18,12 +18,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
   setup :variants
 
   setup do
-    user = insert(:user)
-
-    [
-      user: user,
-      order: insert(:order, user_id: user.id)
-    ]
+    [order: insert(:order)]
   end
 
   describe "create_changeset/2" do

--- a/apps/snitch_core/test/data/schema/payment/card_payment_test.exs
+++ b/apps/snitch_core/test/data/schema/payment/card_payment_test.exs
@@ -6,8 +6,13 @@ defmodule Snitch.Data.Schema.CardPaymentTest do
 
   alias Snitch.Data.Schema.CardPayment
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [
+      user: insert(:user),
+      order: insert(:order)
+    ]
+  end
+
   setup :payment_methods
   setup :payments
 

--- a/apps/snitch_core/test/data/schema/payment/payment_test.exs
+++ b/apps/snitch_core/test/data/schema/payment/payment_test.exs
@@ -6,8 +6,10 @@ defmodule Snitch.Data.Schema.PaymentTest do
 
   alias Snitch.Data.Schema.Payment
 
-  setup :user_with_address
-  setup :an_order
+  setup do
+    [order: insert(:order)]
+  end
+
   setup :payment_methods
 
   test "Payments invalidate bad type", context do

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -3,7 +3,6 @@ defmodule Snitch.Data.Schema.UserTest do
   use Snitch.DataCase
 
   import Ecto.Changeset, only: [apply_changes: 1]
-  import Snitch.Factory
 
   alias Snitch.Data.Schema.User
 

--- a/apps/snitch_core/test/domain/order/order_test.exs
+++ b/apps/snitch_core/test/domain/order/order_test.exs
@@ -28,7 +28,7 @@ defmodule Snitch.Domain.OrderTest do
 
   describe "compute_taxes_changeset/1" do
     setup do
-      [order: insert(:order, state: "foo", user: build(:user))]
+      [order: insert(:order, state: "foo")]
     end
 
     setup :variants

--- a/apps/snitch_core/test/domain/order/transitions_test.exs
+++ b/apps/snitch_core/test/domain/order/transitions_test.exs
@@ -31,7 +31,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
 
       [
         patna: patna,
-        order: struct(insert(:order, user: build(:user)))
+        order: insert(:order)
       ]
     end
 
@@ -139,7 +139,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
 
   describe "persist_shipment" do
     setup do
-      [order: insert(:order, user: build(:user))]
+      [order: insert(:order)]
     end
 
     test "when shipment is empty", %{order: order} do
@@ -169,7 +169,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
     setup :embedded_shipping_methods
 
     setup %{embedded_shipping_methods: methods} do
-      order = insert(:order, user: build(:user))
+      order = insert(:order)
 
       [order: order, packages: [insert(:package, shipping_methods: methods, order: order)]]
     end

--- a/apps/snitch_core/test/domain/shipment_test.exs
+++ b/apps/snitch_core/test/domain/shipment_test.exs
@@ -432,7 +432,7 @@ defmodule Snitch.Domain.ShipmentTest do
 
   describe "to_package/1" do
     setup do
-      [order: insert(:order, user: build(:user))]
+      [order: insert(:order)]
     end
 
     setup :variants

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -205,9 +205,9 @@ defmodule Snitch.Factory do
     [variants: insert_list(count, :random_variant)]
   end
 
-  def an_order(context) do
-    %{user: user} = context
-    [order: insert(:order, user_id: user.id)]
+  def orders(context) do
+    count = Map.get(context, :order_count, 1)
+    [orders: insert_list(count, :order)]
   end
 
   def payment_methods(_context) do


### PR DESCRIPTION
## Motivation
This change gets rid of `order\.(.*_)?total` fields.

* Drastically reduces the locations where line_item total was computed.
* Updated the views in `admin_app`.

Migrations
----------
Remove `:total`, `:promo_total`, `:item_total` and `:adjustment_total`
from `Order`.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
