### PR TITLE
Add tax fields in Package, PackageItem

### DIFF
--- a/apps/snitch_core/lib/core/data/model/package.ex
+++ b/apps/snitch_core/lib/core/data/model/package.ex
@@ -24,8 +24,7 @@ defmodule Snitch.Data.Model.Package do
   @doc """
   Updates the `package` with supplied `params`.
 
-  To add, update, or remove individual `PackageItem`s, please use
-  `Snitch.Data.Model.PackageItem`.
+  To update the `:items` of the `package`, use `Snitch.Data.Model.PackageItem`.
   """
   @spec update(Package.t(), map) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def update(package, params) do

--- a/apps/snitch_core/lib/core/data/schema/line_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/line_item.ex
@@ -30,8 +30,8 @@ defmodule Snitch.Data.Schema.LineItem do
     line_item
     |> cast(params, @cast_fields)
     |> validate_required(@cast_fields)
-    |> foreign_key_constraint(:order_id)
-    |> foreign_key_constraint(:variant_id)
+    |> assoc_constraint(:order)
+    |> assoc_constraint(:variant)
     |> common_changeset()
   end
 
@@ -43,8 +43,8 @@ defmodule Snitch.Data.Schema.LineItem do
     line_item
     |> cast(params, @create_fields)
     |> validate_required(@create_fields)
-    |> foreign_key_constraint(:order_id)
-    |> foreign_key_constraint(:variant_id)
+    |> assoc_constraint(:order)
+    |> assoc_constraint(:variant)
     |> common_changeset()
   end
 

--- a/apps/snitch_core/lib/core/data/schema/package.ex
+++ b/apps/snitch_core/lib/core/data/schema/package.ex
@@ -120,7 +120,7 @@ defmodule Snitch.Data.Schema.Package do
   def shipping_changeset(package, params) do
     package
     |> update_changeset(params)
-    |> validate_required(@shipping_preferences_fields)
+    |> validate_required(@shipping_fields)
   end
 
   defp common_changeset(package_changeset) do

--- a/apps/snitch_core/lib/core/data/schema/package.ex
+++ b/apps/snitch_core/lib/core/data/schema/package.ex
@@ -9,10 +9,10 @@ defmodule Snitch.Data.Schema.Package do
   alias Snitch.Data.Schema.{Order, PackageItem, ShippingCategory, ShippingMethod, StockLocation}
 
   @typedoc """
-  A Package gets shipped to a user.
+  A Package that gets shipped to a user.
 
-  The money fields are used to accurately determine taxes and generate shipping
-  labels.
+  Note that both `Package` and `PackageItem` have the `:shipping_tax` field and
+  `package.shipping_tax` is NOT the sum of package_item.shipping_tax`.
 
   ## Fields
 
@@ -31,8 +31,20 @@ defmodule Snitch.Data.Schema.Package do
   #### `:cost`
   The shipping cost for the chosen `:shipping_method`.
 
-  #### `:*_total`
-  These totals are shipping related, and are applied _over the_ `:cost`.
+  #### `:shipping_tax`
+  The shipping tax on this package. This is different from the taxes on the
+  constituent package items. The total shipping tax for a package is thus:
+  ```
+  total_tax_on_shipping_of_items =
+    package.items
+    |> Stream.map(fn %{shipping_tax: tax} -> tax end)
+    |> Enum.reduce(&Money.add!/2)
+
+  total_shipping_tax = Money.add!(
+    package.shipping_tax, 
+    total_tax_on_shipping_of_items
+  )
+  ```
 
   #### `:origin`
   The `StockLocation` where this package originates from.
@@ -47,10 +59,7 @@ defmodule Snitch.Data.Schema.Package do
     embeds_many(:shipping_methods, EmbeddedShippingMethod, on_replace: :delete)
 
     field(:cost, Money.Ecto.Composite.Type)
-    field(:total, Money.Ecto.Composite.Type)
-    field(:tax_total, Money.Ecto.Composite.Type)
-    field(:adjustment_total, Money.Ecto.Composite.Type)
-    field(:promo_total, Money.Ecto.Composite.Type)
+    field(:shipping_tax, Money.Ecto.Composite.Type)
 
     belongs_to(:order, Order)
     belongs_to(:origin, StockLocation)
@@ -62,11 +71,11 @@ defmodule Snitch.Data.Schema.Package do
     timestamps()
   end
 
-  @price_fields ~w(cost tax_total adjustment_total promo_total total)a
+  @price_fields ~w(cost shipping_tax)a
   @update_fields ~w(state shipped_at tracking shipping_method_id)a ++ @price_fields
-  @shipping_preferences_fields [:shipping_method_id | @price_fields]
-  @create_fields ~w(order_id origin_id shipping_category_id)a ++ @update_fields
+  @shipping_fields [:shipping_method_id | @price_fields]
 
+  @create_fields ~w(order_id origin_id shipping_category_id)a ++ @update_fields
   @required_fields ~w(state order_id origin_id shipping_category_id)a
 
   @doc """
@@ -92,23 +101,32 @@ defmodule Snitch.Data.Schema.Package do
 
   @doc """
   Returns a `Package` changeset to update the `package`.
-
-  The `shipping_method` and totals of the `package` must either be changed or
-  already set previously.
   """
   @spec update_changeset(t, map) :: Ecto.Changeset.t()
-  def update_changeset(%__MODULE__{} = package, params) do
+  def update_changeset(package, params) do
     package
     |> cast(params, @update_fields)
-    |> validate_required(@shipping_preferences_fields)
     |> cast_embed(:shipping_methods)
     |> common_changeset()
+  end
+
+  @doc """
+  Returns a `Package` changeset to update the `package`.
+
+  The `:shipping_method`, `:cost` and `shipping_tax` must either be changed via
+  `params` or already set previously in the `package`.
+  """
+  @spec shipping_changeset(t, map) :: Ecto.Changeset.t()
+  def shipping_changeset(package, params) do
+    package
+    |> update_changeset(params)
+    |> validate_required(@shipping_preferences_fields)
   end
 
   defp common_changeset(package_changeset) do
     package_changeset
     |> foreign_key_constraint(:shipping_method_id)
     |> validate_amount(:cost)
-    |> validate_amount(:tax_total)
+    |> validate_amount(:shipping_tax)
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/package_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/package_item.ex
@@ -47,7 +47,6 @@ defmodule Snitch.Data.Schema.PackageItem do
   ## Fields
 
   ### `:quantity`
-
   The number of units (of this item) that are currently "on hand" at the stock
   location. The package can be shipped only when this becomes equal to the
   quantity ordered.
@@ -57,19 +56,29 @@ defmodule Snitch.Data.Schema.PackageItem do
   origin stock location.
 
   ### `:delta`
-
   The difference between the `:quantity` and the number of units "on
   hand".
+
+  ### `:tax`
+  The tax levied over (or included in) the cost of the line item, as applicable
+  when the line item is sold from the `:origin` stock location.
+  This does not include any shipping tax components.
+
+  ### `:shipping_tax`
+  The sum of all shipping taxes that apply for the shipping of this item from
+  the `origin` stock location.
   """
   @type t :: %__MODULE__{}
 
-  # TODO: :backordered can be made a virtual field
+  # TODO: :backordered could be made a virtual field...
   schema "snitch_package_items" do
     field(:number, Nanoid, autogenerate: true)
     field(:state, :string)
     field(:quantity, :integer, default: 0)
     field(:delta, :integer, default: 0)
     field(:backordered?, :boolean)
+    field(:tax, Money.Ecto.Composite.Type)
+    field(:shipping_tax, Money.Ecto.Composite.Type)
 
     belongs_to(:variant, Variant)
     belongs_to(:line_item, LineItem)
@@ -80,9 +89,9 @@ defmodule Snitch.Data.Schema.PackageItem do
     timestamps()
   end
 
-  @create_fields ~w(state delta quantity line_item_id variant_id package_id)a
+  @create_fields ~w(state delta quantity line_item_id variant_id package_id tax shipping_tax)a
   @required_fields ~w(state quantity line_item_id variant_id)a
-  @update_fields ~w(state quantity delta)a
+  @update_fields ~w(state quantity delta tax shipping_tax)a
 
   @doc """
   Returns a `PackageItem` changeset to create a new `package_item`.
@@ -113,10 +122,12 @@ defmodule Snitch.Data.Schema.PackageItem do
     package_item_changeset
     |> validate_number(:quantity, greater_than: -1)
     |> validate_number(:delta, greater_than: -1)
-    |> validate_backorder_and_delta()
+    |> validate_amount(:tax)
+    |> validate_amount(:shipping_tax)
+    |> set_backordered()
   end
 
-  defp validate_backorder_and_delta(%Ecto.Changeset{valid?: true} = changeset) do
+  defp set_backordered(%Ecto.Changeset{valid?: true} = changeset) do
     case fetch_field(changeset, :delta) do
       {_, delta} when delta == 0 ->
         put_change(changeset, :backordered?, false)
@@ -129,5 +140,5 @@ defmodule Snitch.Data.Schema.PackageItem do
     end
   end
 
-  defp validate_backorder_and_delta(%Ecto.Changeset{} = cs), do: cs
+  defp set_backordered(%Ecto.Changeset{} = cs), do: cs
 end

--- a/apps/snitch_core/lib/core/data/schema/package_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/package_item.ex
@@ -90,7 +90,7 @@ defmodule Snitch.Data.Schema.PackageItem do
   end
 
   @create_fields ~w(state delta quantity line_item_id variant_id package_id tax shipping_tax)a
-  @required_fields ~w(state quantity line_item_id variant_id)a
+  @required_fields ~w(state quantity line_item_id variant_id tax)a
   @update_fields ~w(state quantity delta tax shipping_tax)a
 
   @doc """

--- a/apps/snitch_core/lib/core/domain/order/order.ex
+++ b/apps/snitch_core/lib/core/domain/order/order.ex
@@ -1,37 +1,32 @@
 defmodule Snitch.Domain.Order do
   @moduledoc """
-  Order helpers
+  Order helpers.
   """
+
+  @editable_states ~w(cart address delivery payment)
 
   use Snitch.Domain
 
-  alias Ecto.Changeset
-  alias Snitch.Data.Model.LineItem
+  import Ecto.Changeset
+
   alias Snitch.Data.Schema.Order
-  alias Snitch.Tools.Money, as: MoneyTools
 
-  @spec add_line_item(Order.t(), LineItem.t()) :: {:ok, Order.t()} | {:error, term}
-  def add_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
+  @spec validate_change(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def validate_change(%{valid?: false} = changeset), do: changeset
 
-  @spec update_line_item(Order.t(), LineItem.t()) :: {:ok, Order.t()} | {:error, term}
-  def update_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
-
-  @spec remove_line_item(Order.t(), LineItem.t()) :: {:ok, Order.t()} | {:error, term}
-  def remove_line_item(%Order{state: "cart"} = order, _), do: {:ok, order}
-
-  @spec compute_taxes_changeset(Changeset.t()) :: Changeset.t()
-  def compute_taxes_changeset(%Changeset{valid?: false} = changeset), do: changeset
-
-  def compute_taxes_changeset(%Changeset{valid?: true, data: %Order{} = o} = changeset) do
-    order = Repo.preload(o, :line_items)
-    item_total = LineItem.compute_total(order.line_items)
-
-    # TODO: Use order.billing_address and order.shipping_address
-    tax_total = MoneyTools.zero!()
-
-    changeset
-    |> Changeset.put_change(:item_total, item_total)
-    |> Changeset.put_change(:tax_total, tax_total)
-    |> Changeset.put_change(:total, Money.add!(tax_total, item_total))
+  def validate_change(%{valid?: true} = changeset) do
+    prepare_changes(changeset, fn changeset ->
+      with {_, order_id} <- fetch_field(changeset, :order_id),
+           %Order{state: order_state} <- changeset.repo.get(Order, order_id) do
+        if order_state in @editable_states do
+          changeset
+        else
+          add_error(changeset, :order, "has been frozen", validation: :state, state: order_state)
+        end
+      else
+        _ ->
+          changeset
+      end
+    end)
   end
 end

--- a/apps/snitch_core/lib/core/domain/order/transitions.ex
+++ b/apps/snitch_core/lib/core/domain/order/transitions.ex
@@ -14,7 +14,6 @@ defmodule Snitch.Domain.Order.Transitions do
   alias Snitch.Data.Model.Package
   alias Snitch.Data.Schema.Order
 
-  alias Snitch.Domain.Order, as: OrderDomain
   alias Snitch.Domain.Package, as: PackageDomain
   alias Snitch.Domain.{Shipment, ShipmentEngine, Splitters.Weight}
 
@@ -42,15 +41,12 @@ defmodule Snitch.Domain.Order.Transitions do
         } = context
       ) do
     changeset =
-      order
-      |> Order.partial_update_changeset(%{billing_address: billing, shipping_address: shipping})
-      |> OrderDomain.compute_taxes_changeset()
+      Order.partial_update_changeset(
+        order,
+        %{billing_address: billing, shipping_address: shipping}
+      )
 
-    if changeset.valid? do
-      struct(context, multi: Multi.update(multi, :order, changeset))
-    else
-      struct(context, valid?: false, errors: [order: changeset])
-    end
+    struct(context, multi: Multi.update(multi, :order, changeset))
   end
 
   def associate_address(%Context{} = context), do: struct(context, valid?: false)

--- a/apps/snitch_core/lib/core/domain/package.ex
+++ b/apps/snitch_core/lib/core/domain/package.ex
@@ -3,35 +3,40 @@ defmodule Snitch.Domain.Package do
   Package helpers.
   """
 
-  alias Snitch.Data.Model.Package
+  use Snitch.Domain
+
+  alias Ecto.Changeset
+  alias Snitch.Data.Schema.Package
   alias Snitch.Tools.Money, as: MoneyTools
 
+  @doc """
+  Saves
+  """
+  @spec set_shipping_method(Package.t(), non_neg_integer) :: Package.t()
   def set_shipping_method(package, shipping_method_id) do
     # TODO: clean up this hack!
     #
     # if we can't find the selected shipping method, we must force the
     # Packge.update to fail
     # Eventually replace with some nice API contract/validator.
-    zero = MoneyTools.zero!()
-
     shipping_method =
-      Enum.find(package.shipping_methods, %{cost: zero, id: nil}, fn %{id: id} ->
+      Enum.find(package.shipping_methods, %{cost: Money.zero(:INR), id: nil}, fn %{id: id} ->
         id == shipping_method_id
       end)
 
-    package_total =
-      Enum.reduce(
-        [shipping_method.cost],
-        &Money.add!/2
-      )
-
-    Package.update(package, %{
+    params = %{
       cost: shipping_method.cost,
-      total: package_total,
-      tax_total: zero,
-      promo_total: zero,
-      adjustment_total: zero,
+      shipping_tax: shipping_tax(package),
       shipping_method_id: shipping_method.id
-    })
+    }
+
+    package
+    |> Package.shipping_changeset(params)
+    |> Repo.update()
+  end
+
+  @spec shipping_tax(Package.t()) :: Money.t()
+  def shipping_tax(_package) do
+    MoneyTools.zero!()
   end
 end

--- a/apps/snitch_core/lib/core/domain/package.ex
+++ b/apps/snitch_core/lib/core/domain/package.ex
@@ -5,7 +5,6 @@ defmodule Snitch.Domain.Package do
 
   use Snitch.Domain
 
-  alias Ecto.Changeset
   alias Snitch.Data.Schema.Package
   alias Snitch.Tools.Money, as: MoneyTools
 

--- a/apps/snitch_core/lib/core/domain/package_item.ex
+++ b/apps/snitch_core/lib/core/domain/package_item.ex
@@ -3,17 +3,16 @@ defmodule Snitch.Domain.PackageItem do
   PackageItem helpers.
   """
 
-  alias Ecto.Changeset
-  alias Snitch.Data.Schema.PackageItem
+  alias Snitch.Data.Schema.{PackageItem, StockLocation}
   alias Snitch.Tools.Money, as: MoneyTools
 
-  @spec tax(PackageItem.t()) :: Money.t()
-  def tax(package_item) do
+  @spec tax(PackageItem.t(), StockLocation.t()) :: Money.t()
+  def tax(_package_item, _stock_location) do
     MoneyTools.zero!()
   end
 
-  @spec shipping_tax(PackageItem.t()) :: Money.t()
-  def shipping_tax(package_item) do
+  @spec shipping_tax(PackageItem.t(), StockLocation.t()) :: Money.t()
+  def shipping_tax(_package_item, _stock_location) do
     MoneyTools.zero!()
   end
 end

--- a/apps/snitch_core/lib/core/domain/package_item.ex
+++ b/apps/snitch_core/lib/core/domain/package_item.ex
@@ -1,0 +1,19 @@
+defmodule Snitch.Domain.PackageItem do
+  @moduledoc """
+  PackageItem helpers.
+  """
+
+  alias Ecto.Changeset
+  alias Snitch.Data.Schema.PackageItem
+  alias Snitch.Tools.Money, as: MoneyTools
+
+  @spec tax(PackageItem.t()) :: Money.t()
+  def tax(package_item) do
+    MoneyTools.zero!()
+  end
+
+  @spec shipping_tax(PackageItem.t()) :: Money.t()
+  def shipping_tax(package_item) do
+    MoneyTools.zero!()
+  end
+end

--- a/apps/snitch_core/lib/core/domain/shipment.ex
+++ b/apps/snitch_core/lib/core/domain/shipment.ex
@@ -1,4 +1,5 @@
 defmodule Snitch.Domain.Shipment do
+  # TODO: migrate to the Package schema.
   @moduledoc """
   The coordinator, packer, estimator and prioritizer -- all in one.
 
@@ -33,6 +34,23 @@ defmodule Snitch.Domain.Shipment do
   alias Snitch.Data.Schema.{Order}
   alias Snitch.Domain.{ShippingMethod, Zone}
 
+  @doc """
+  Returns a list of potentially shippable packages.
+
+  The function fetches all the stock information (from all stock locations) that
+  is relevant to this order and attempts to fulfill the order separately from
+  each stock location.
+
+  The final result is a "flattened" list of maps, each representing a
+  `Package.t` struct.
+
+  ## Note
+  Some `Package.t` fields are not computed, like: `package.tax`.
+
+  Similarily, some fields of the constituent `PackageItem` are not computed as
+  well, like: `package_item.tax`, `package_item.shipping_tax`.
+  """
+  @spec default_packages(Order.t()) :: [map]
   def default_packages(%Order{} = order) do
     order = Repo.preload(order, line_items: [])
     variant_ids = Enum.map(order.line_items, fn %{variant_id: id} -> id end)

--- a/apps/snitch_core/priv/repo/migrations/20180705190618_remove_order_total_fields.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180705190618_remove_order_total_fields.exs
@@ -9,7 +9,7 @@ defmodule Snitch.Repo.Migrations.RemoveOrderTotalFields do
       remove :adjustment_total
     end
   end
-  
+
   def down do
     alter table("snitch_orders") do
       add :total, :money_with_currency

--- a/apps/snitch_core/priv/repo/migrations/20180705195518_change_package_for_tax_field.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180705195518_change_package_for_tax_field.exs
@@ -1,0 +1,33 @@
+defmodule Snitch.Repo.Migrations.ChangePackageForTaxField do
+  use Ecto.Migration
+
+  def up do
+    alter table("snitch_packages") do
+      remove :total
+      remove :tax_total
+      remove :promo_total
+      remove :adjustment_total
+      add :shipping_tax, :money_with_currency
+    end
+
+    alter table("snitch_package_items") do
+      add :tax, :money_with_currency
+      add :shipping_tax, :money_with_currency
+    end
+  end
+
+  def down do
+    alter table("snitch_packages") do
+      add :total, :money_with_currency
+      add :tax_total, :money_with_currency
+      add :promo_total, :money_with_currency
+      add :adjustment_total, :money_with_currency
+      remove :shipping_tax
+    end
+
+    alter table("snitch_package_itemss") do
+      remove :tax
+      remove :shipping_tax
+    end
+  end
+end

--- a/apps/snitch_core/test/data/model/package_item_test.exs
+++ b/apps/snitch_core/test/data/model/package_item_test.exs
@@ -22,7 +22,8 @@ defmodule Snitch.Data.Model.PackageItemTest do
     backordered?: true,
     variant_id: nil,
     line_item_id: nil,
-    package_id: nil
+    package_id: nil,
+    tax: Money.zero(:INR)
   }
 
   describe "create/1" do
@@ -37,7 +38,7 @@ defmodule Snitch.Data.Model.PackageItemTest do
                PackageItem.create(%{@params | line_item_id: -1, variant_id: -1, package_id: -1})
 
       refute changeset.valid?
-      assert %{line_item_id: ["does not exist"]} = errors_on(changeset)
+      assert %{line_item_id: ["does not exist"]} == errors_on(changeset)
 
       assert {:error, changeset} =
                PackageItem.create(%{
@@ -48,7 +49,7 @@ defmodule Snitch.Data.Model.PackageItemTest do
                })
 
       refute changeset.valid?
-      assert %{variant_id: ["does not exist"]} = errors_on(changeset)
+      assert %{variant_id: ["does not exist"]} == errors_on(changeset)
 
       assert {:error, changeset} =
                PackageItem.create(%{
@@ -59,7 +60,7 @@ defmodule Snitch.Data.Model.PackageItemTest do
                })
 
       refute changeset.valid?
-      assert %{package_id: ["does not exist"]} = errors_on(changeset)
+      assert %{package_id: ["does not exist"]} == errors_on(changeset)
     end
 
     @tag variant_count: 1,

--- a/apps/snitch_core/test/data/model/package_test.exs
+++ b/apps/snitch_core/test/data/model/package_test.exs
@@ -119,34 +119,12 @@ defmodule Snitch.Data.Model.PackageTest do
       assert [_] = package.shipping_methods
 
       params = %{
-        shipping_method_id: sm.id,
-        cost: Money.new(1, :USD),
-        total: Money.new(1, :USD),
-        tax_total: Money.zero(:USD),
-        promo_total: Money.zero(:USD),
-        adjustment_total: Money.zero(:USD)
+        shipping_method_id: sm.id
       }
 
       {:ok, updated_package} = Package.update(package, params)
 
       {:ok, _} = Package.update(updated_package, %{shipping_methods: []})
-    end
-
-    @tag variant_count: 1,
-         shipping_category_count: 1,
-         state_zone_count: 1
-    test "fails with invalid params", %{package: package} do
-      bad_params = %{cost: Money.new(-1, :USD), tax_total: Money.new(-1, :USD)}
-      {:error, cs} = Package.update(package, bad_params)
-
-      assert %{
-               adjustment_total: ["can't be blank"],
-               promo_total: ["can't be blank"],
-               shipping_method_id: ["can't be blank"],
-               total: ["can't be blank"],
-               cost: ["must be equal or greater than 0"],
-               tax_total: ["must be equal or greater than 0"]
-             } == errors_on(cs)
     end
   end
 end

--- a/apps/snitch_core/test/data/model/package_test.exs
+++ b/apps/snitch_core/test/data/model/package_test.exs
@@ -24,7 +24,7 @@ defmodule Snitch.Data.Model.PackageTest do
     order_id: 0,
     origin_id: 0,
     cost: Money.new(0, :USD),
-    tax_total: Money.new(0, :USD),
+    tax: Money.new(0, :USD),
     shipping_category_id: 0,
     shipping_method_id: nil
   }
@@ -68,23 +68,23 @@ defmodule Snitch.Data.Model.PackageTest do
 
       params = %{@params | shipping_method_id: 0, shipping_methods: [%ShippingMethod{}]}
       assert {:error, cs} = Package.create(params)
-      assert %{order_id: ["does not exist"]} = errors_on(cs)
+      assert %{order_id: ["does not exist"]} == errors_on(cs)
 
       params = %{params | order_id: order.id}
       assert {:error, cs} = Package.create(params)
-      assert %{origin_id: ["does not exist"]} = errors_on(cs)
+      assert %{origin_id: ["does not exist"]} == errors_on(cs)
 
       params = %{params | origin_id: origin.id}
       assert {:error, cs} = Package.create(params)
-      assert %{shipping_category_id: ["does not exist"]} = errors_on(cs)
+      assert %{shipping_category_id: ["does not exist"]} == errors_on(cs)
 
       params = %{params | shipping_category_id: sc.id}
       assert {:error, cs} = Package.create(params)
-      assert %{shipping_method_id: ["does not exist"]} = errors_on(cs)
+      assert %{shipping_method_id: ["does not exist"]} == errors_on(cs)
 
       params = %{params | shipping_methods: []}
       assert {:error, cs} = Package.create(params)
-      assert %{shipping_methods: ["can't be blank"]} = errors_on(cs)
+      assert %{shipping_methods: ["can't be blank"]} == errors_on(cs)
     end
   end
 

--- a/apps/snitch_core/test/data/schema/line_item_test.exs
+++ b/apps/snitch_core/test/data/schema/line_item_test.exs
@@ -30,7 +30,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
                quantity: ["can't be blank"],
                unit_price: ["can't be blank"],
                variant_id: ["can't be blank"]
-             } = errors_on(cs)
+             } == errors_on(cs)
     end
 
     test "fails without price fields", %{order: order, variants: [variant | _]} do
@@ -41,7 +41,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
             order_id: order.id
         })
 
-      assert %{unit_price: ["can't be blank"]} = errors_on(cs)
+      assert %{unit_price: ["can't be blank"]} == errors_on(cs)
     end
 
     test "fails with bad price fields", %{order: order, variants: [variant | _]} do
@@ -53,7 +53,7 @@ defmodule Snitch.Data.Schema.LineItemTest do
             unit_price: Money.new(-1, :USD)
         })
 
-      assert %{unit_price: ["must be equal or greater than 0"]} = errors_on(cs)
+      assert %{unit_price: ["must be equal or greater than 0"]} == errors_on(cs)
     end
 
     test "with price fields", %{order: order, variants: [variant | _]} do

--- a/apps/snitch_core/test/data/schema/package_item_test.exs
+++ b/apps/snitch_core/test/data/schema/package_item_test.exs
@@ -14,7 +14,9 @@ defmodule Snitch.Data.Schema.PackageItemTest do
     backordered?: false,
     variant_id: 0,
     line_item_id: 0,
-    package_id: 0
+    package_id: 0,
+    tax: nil,
+    shipping_tax: nil
   }
 
   describe "create_changeset/2" do
@@ -22,15 +24,14 @@ defmodule Snitch.Data.Schema.PackageItemTest do
       assert cs = %{valid?: true} = PackageItem.create_changeset(%PackageItem{}, @params)
       assert {:ok, true} = fetch_change(cs, :backordered?)
 
-      assert cs =
-               %{valid?: true} =
-               PackageItem.create_changeset(%PackageItem{}, %{@params | delta: 0})
-
+      cs = PackageItem.create_changeset(%PackageItem{}, %{@params | delta: 0})
+      assert cs.valid?
       assert {:ok, false} = fetch_change(cs, :backordered?)
     end
 
     test "with missing params" do
-      assert cs = %{valid?: false} = PackageItem.create_changeset(%PackageItem{}, %{})
+      cs = PackageItem.create_changeset(%PackageItem{}, %{})
+      refute cs.valid?
 
       assert %{
                line_item_id: ["can't be blank"],
@@ -40,13 +41,28 @@ defmodule Snitch.Data.Schema.PackageItemTest do
     end
 
     test "with invalid quantity, delta" do
-      assert cs =
-               %{valid?: false} =
-               PackageItem.create_changeset(%PackageItem{}, %{@params | quantity: -2, delta: -1})
+      cs = PackageItem.create_changeset(%PackageItem{}, %{@params | quantity: -2, delta: -1})
+      refute cs.valid?
 
       assert %{
                delta: ["must be greater than -1"],
                quantity: ["must be greater than -1"]
+             } = errors_on(cs)
+    end
+
+    test "with invalid tax, shipping_tax" do
+      bad_money = Money.new(-1, :USD)
+
+      cs =
+        PackageItem.create_changeset(%PackageItem{}, %{
+          @params
+          | tax: bad_money,
+            shipping_tax: bad_money
+        })
+
+      assert %{
+               shipping_tax: ["must be equal or greater than 0"],
+               tax: ["must be equal or greater than 0"]
              } = errors_on(cs)
     end
   end

--- a/apps/snitch_core/test/data/schema/package_item_test.exs
+++ b/apps/snitch_core/test/data/schema/package_item_test.exs
@@ -15,18 +15,18 @@ defmodule Snitch.Data.Schema.PackageItemTest do
     variant_id: 0,
     line_item_id: 0,
     package_id: 0,
-    tax: nil,
+    tax: Money.zero(:INR),
     shipping_tax: nil
   }
 
   describe "create_changeset/2" do
     test "with valid params, and backorder is computed correctly" do
       assert cs = %{valid?: true} = PackageItem.create_changeset(%PackageItem{}, @params)
-      assert {:ok, true} = fetch_change(cs, :backordered?)
+      assert {:ok, true} == fetch_change(cs, :backordered?)
 
       cs = PackageItem.create_changeset(%PackageItem{}, %{@params | delta: 0})
       assert cs.valid?
-      assert {:ok, false} = fetch_change(cs, :backordered?)
+      assert {:ok, false} == fetch_change(cs, :backordered?)
     end
 
     test "with missing params" do
@@ -36,8 +36,9 @@ defmodule Snitch.Data.Schema.PackageItemTest do
       assert %{
                line_item_id: ["can't be blank"],
                state: ["can't be blank"],
-               variant_id: ["can't be blank"]
-             } = errors_on(cs)
+               variant_id: ["can't be blank"],
+               tax: ["can't be blank"]
+             } == errors_on(cs)
     end
 
     test "with invalid quantity, delta" do

--- a/apps/snitch_core/test/domain/order/order_test.exs
+++ b/apps/snitch_core/test/domain/order/order_test.exs
@@ -1,74 +1,41 @@
 defmodule Snitch.Domain.OrderTest do
   use ExUnit.Case, async: true
   use Snitch.DataCase
+  use Ecto.Schema
 
-  import Mox
+  import Ecto.Changeset, only: [change: 2]
   import Snitch.Factory
 
-  alias Snitch.Data.Schema.Order
   alias Snitch.Domain.Order, as: OrderDomain
 
-  describe "add_line_item/2" do
-    test "when order.state is `cart`" do
-      assert {:ok, %Order{}} = OrderDomain.add_line_item(%Order{state: "cart"}, nil)
-    end
-  end
+  describe "validate_changes/1" do
+    test "with order in frozen state" do
+      {:error, cs} =
+        :line_item
+        |> insert(order: build(:order, state: "foo"))
+        |> change(%{quantity: 3})
+        |> OrderDomain.validate_change()
+        |> Repo.update()
 
-  describe "update_line_item/2" do
-    test "when order.state is `cart`" do
-      assert {:ok, %Order{}} = OrderDomain.update_line_item(%Order{state: "cart"}, nil)
-    end
-  end
-
-  describe "remove_line_item/2" do
-    test "when order.state is `cart`" do
-      assert {:ok, %Order{}} = OrderDomain.remove_line_item(%Order{state: "cart"}, nil)
-    end
-  end
-
-  describe "compute_taxes_changeset/1" do
-    setup do
-      [order: insert(:order, state: "foo")]
+      assert %{order: ["has been frozen"]} == errors_on(cs)
     end
 
-    setup :variants
-    setup :line_items
-
-    test "for order in `cart`" do
-      expect(Snitch.Tools.DefaultsMock, :fetch, 2, fn :currency -> {:ok, :USD} end)
-
-      cs =
-        %Order{state: "cart"}
-        |> Order.partial_update_changeset(%{})
-        |> OrderDomain.compute_taxes_changeset()
-
-      assert cs.valid?
-
-      assert cs.changes == %{
-               item_total: Money.zero(:USD),
-               tax_total: Money.zero(:USD),
-               total: Money.zero(:USD)
-             }
+    test "with order in editable state" do
+      assert {:ok, _} =
+               :line_item
+               |> insert(order: build(:order))
+               |> change(%{quantity: 3})
+               |> OrderDomain.validate_change()
+               |> Repo.update()
     end
 
-    @tag variant_count: 1
-    test "for order in with items", %{order: order, line_items: [item]} do
-      expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :USD} end)
-
-      cs =
-        order
-        |> Order.partial_update_changeset(%{})
-        |> OrderDomain.compute_taxes_changeset()
-
-      total = Money.mult!(item.unit_price, item.quantity)
-
-      assert %{
-               item_total: total,
-               total: total,
-               tax_total: Money.zero(:USD)
-             } == cs.changes
-
-      assert cs.valid?
+    test "noop when `:changes` is empty" do
+      assert {:ok, _} =
+               :line_item
+               |> insert(order: build(:order))
+               |> change(%{})
+               |> OrderDomain.validate_change()
+               |> Repo.update()
     end
   end
 end

--- a/apps/snitch_core/test/domain/package_item_test.exs
+++ b/apps/snitch_core/test/domain/package_item_test.exs
@@ -1,0 +1,20 @@
+defmodule Snitch.Domain.PackageItemTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  alias Snitch.Domain.PackageItem
+
+  setup :verify_on_exit!
+
+  test "tax/1" do
+    expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :INR} end)
+    assert PackageItem.tax(nil) == Money.zero(:INR)
+  end
+
+  test "shipping_tax/1" do
+    expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :INR} end)
+    assert PackageItem.shipping_tax(nil) == Money.zero(:INR)
+  end
+end

--- a/apps/snitch_core/test/domain/package_item_test.exs
+++ b/apps/snitch_core/test/domain/package_item_test.exs
@@ -10,11 +10,11 @@ defmodule Snitch.Domain.PackageItemTest do
 
   test "tax/1" do
     expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :INR} end)
-    assert PackageItem.tax(nil) == Money.zero(:INR)
+    assert PackageItem.tax(nil, nil) == Money.zero(:INR)
   end
 
   test "shipping_tax/1" do
     expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :INR} end)
-    assert PackageItem.shipping_tax(nil) == Money.zero(:INR)
+    assert PackageItem.shipping_tax(nil, nil) == Money.zero(:INR)
   end
 end

--- a/apps/snitch_core/test/domain/package_test.exs
+++ b/apps/snitch_core/test/domain/package_test.exs
@@ -24,10 +24,7 @@ defmodule Snitch.Domain.PackageTest do
       assert {:ok, package} = Package.set_shipping_method(package, sm.id)
       assert package.shipping_method_id
       assert package.cost
-      assert package.tax_total
-      assert package.promo_total
-      assert package.adjustment_total
-      assert package.total
+      assert package.shipping_tax
     end
 
     @tag shipping_method_count: 1

--- a/apps/snitch_core/test/domain/package_test.exs
+++ b/apps/snitch_core/test/domain/package_test.exs
@@ -38,4 +38,9 @@ defmodule Snitch.Domain.PackageTest do
       assert %{shipping_method_id: ["can't be blank"]} == errors_on(cs)
     end
   end
+
+  test "shipping_tax/1" do
+    expect(Snitch.Tools.DefaultsMock, :fetch, fn :currency -> {:ok, :INR} end)
+    assert Package.shipping_tax(nil) == Money.zero(:INR)
+  end
 end

--- a/apps/snitch_core/test/domain/splitters/weight_test.exs
+++ b/apps/snitch_core/test/domain/splitters/weight_test.exs
@@ -2,6 +2,9 @@ defmodule Snitch.Domain.Splitter.WeightTest do
   use ExUnit.Case, async: true
   use Snitch.DataCase
 
+  # TODO: Build the packages by hand, possibly using `Factory.Shipping.shipment!`
+  # not using `Shipment.default_packages/1`
+  import Mox, only: [expect: 4, verify_on_exit!: 1]
   import Snitch.Tools.Helper.{Order, Shipment, Stock, Zone}
 
   alias Snitch.Data.Schema.{Address, Order, StockItem, StockLocation, Variant}
@@ -110,6 +113,7 @@ defmodule Snitch.Domain.Splitter.WeightTest do
   end
 
   setup :stock_items
+  setup :verify_on_exit!
 
   describe "split/1" do
     # Default Packages
@@ -137,6 +141,8 @@ defmodule Snitch.Domain.Splitter.WeightTest do
       address = %Address{state_id: up.id, country_id: india.id}
       line_items = line_items_with_price(vs, [1])
       order = %Order{id: 42, line_items: line_items, shipping_address: address}
+
+      expect(Snitch.Tools.DefaultsMock, :fetch, 2, fn :currency -> {:ok, :USD} end)
 
       packages =
         order
@@ -194,6 +200,8 @@ defmodule Snitch.Domain.Splitter.WeightTest do
     line_items = line_items_with_price(vs, [3, 3])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
 
+    expect(Snitch.Tools.DefaultsMock, :fetch, 4, fn :currency -> {:ok, :USD} end)
+
     packages =
       order
       |> Shipment.default_packages()
@@ -247,6 +255,8 @@ defmodule Snitch.Domain.Splitter.WeightTest do
     address = %Address{state_id: up.id, country_id: india.id}
     line_items = line_items_with_price(vs, [2, 6])
     order = %Order{id: 42, line_items: line_items, shipping_address: address}
+
+    expect(Snitch.Tools.DefaultsMock, :fetch, 3, fn :currency -> {:ok, :USD} end)
 
     packages =
       order

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -160,8 +160,8 @@ defmodule Snitch.Factory do
 
   def role_factory do
     %Role{
-      name: sequence(:role, ["admin", "order-manager"]),
-      description: sequence(:description, ["can manage all", "can manage few"])
+      name: sequence("nobody"),
+      description: "is like everybody"
     }
   end
 

--- a/apps/snitch_core/test/support/factory/shipping.ex
+++ b/apps/snitch_core/test/support/factory/shipping.ex
@@ -41,11 +41,6 @@ defmodule Snitch.Factory.Shipping do
           shipped_at: nil,
           tracking: %{id: "some_tracking_id"},
           shipping_methods: [],
-          cost: Money.new(0, :USD),
-          total: Money.new(0, :USD),
-          tax_total: Money.new(0, :USD),
-          adjustment_total: Money.new(0, :USD),
-          promo_total: Money.new(0, :USD),
           order: build(:order, user: build(:user)),
           origin: build(:stock_location),
           shipping_category: build(:shipping_category)

--- a/apps/snitch_core/test/support/factory/shipping.ex
+++ b/apps/snitch_core/test/support/factory/shipping.ex
@@ -83,7 +83,8 @@ defmodule Snitch.Factory.Shipping do
                 variant: v,
                 delta: 0,
                 quantity: 4,
-                state: :fulfilled
+                state: :fulfilled,
+                tax: Money.zero(:USD)
               }
             ],
             origin: insert(:stock_location),

--- a/apps/snitch_core/test/tools/helpers/taxonomy_test.exs
+++ b/apps/snitch_core/test/tools/helpers/taxonomy_test.exs
@@ -1,5 +1,5 @@
-defmodule Snitch.Tools.Helpers.Taxonomy do
-  use ExUnit.Case, async: false
+defmodule Snitch.Tools.Helpers.TaxonomyTest do
+  use ExUnit.Case, async: true
   use Snitch.DataCase
 
   alias Snitch.Domain.Taxonomy, as: TaxonomyDomain


### PR DESCRIPTION
## Motivation
As described in [this document](https://hackmd.io/3CSql37HRf6_MgPz5zhhRQ), we wish to place tax fields in the package schemas.
The `tax` on each package-item should be calculated upon creation of a shipment, in the transition from `cart` to `address`

## Description
Adds `Package.shipping_changeset` for the `save_shipping_preferences`
event transition, making it easier to work with errors.

Adds the `Domain.Package.shipping_tax/1`, `Domain.PackageItem.tax/1` and
`Domain.PackageItem.shipping_tax/1` functions.

`Shipment.default_packages/1` now attaches the tax on each item.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
