### PR TITLE
Add ProductReview feature

### DIFF
--- a/apps/snitch_core/lib/core/data/model/product_review.ex
+++ b/apps/snitch_core/lib/core/data/model/product_review.ex
@@ -1,0 +1,137 @@
+defmodule Snitch.Data.Model.ProductReview do
+  @moduledoc """
+  API functions ProductReview.
+  """
+
+  alias Ecto.Multi
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.ProductReview
+  alias Snitch.Data.Schema.RatingOption
+  alias Snitch.Data.Schema.Review
+
+  @review_detail %{
+    average_rating: Decimal.new(0),
+    review_count: 0,
+    rating_summary: []
+  }
+
+  @doc """
+  Creates a product review with the supplied params.
+
+  To create a product review the `params` should include
+  `review_attributes` under the `:attributes` key.
+  ## See
+  `Review`
+
+  Also the `rating_option` `struct` should be provided under the
+  `:rating_option_vote` key in the `params`.
+  ## See
+  `Rating`
+  `RatingOption`
+
+  The `id` of the `product` for which review should be created
+  should be passed under the `:product_id` key in `params`.
+  """
+
+  @spec add(map) ::
+          {:ok, Review.t()}
+          | {:error, Ecto.Changeset.t()}
+  def add(params) do
+    Multi.new()
+    |> Multi.run(:review, fn _ ->
+      params = parse_review_params(params)
+      QH.create(Review, params, Repo)
+    end)
+    |> Multi.run(:associate_product, fn %{review: review} ->
+      %{product_id: product_id} = params
+      params = %{product_id: product_id, review_id: review.id}
+      QH.create(ProductReview, params, Repo)
+    end)
+    |> persist()
+  end
+
+  ## TODO To be replaced with a record in database.
+  @doc """
+  Returns the average rating, review_count and rating details for
+  a product.
+
+  The structure returned is a map of following signature:
+  %{
+    average_rating: 3.5 #average rating for the product
+    review_count: 10 # number of reviews for a product
+    rating_detail: [
+      value_1: # values are rating_option codes corresponding to
+                "product" rating
+      value_2:
+      value_n:
+    ]
+  }
+
+  ## See
+  `RatingOption`
+  """
+  @spec review_aggregate(Product.t()) :: map
+  def review_aggregate(product) do
+    reviews =
+      product
+      |> Repo.preload(reviews: [rating_option_vote: :rating_option])
+      |> Map.get(:reviews)
+
+    calculate_aggregate(reviews, length(reviews), @review_detail)
+  end
+
+  ################## private functions #################
+
+  defp calculate_aggregate(_, 0, review_detail) do
+    review_detail
+  end
+
+  defp calculate_aggregate(reviews, count, review_detail) do
+    {rating_detail, sum} =
+      Enum.reduce(reviews, {review_detail.rating_summary, 0}, fn review,
+                                                                 {rating_detail_list, rating_sum} ->
+        code = String.to_atom(review.rating_option_vote.rating_option.code)
+        position = review.rating_option_vote.rating_option.position
+        rating_value = get_rating_value(Keyword.get(rating_detail_list, code)) || 0
+        rating_value = rating_value + 1
+        params = %{value: rating_value, position: position}
+        rating_detail_list = Keyword.put(rating_detail_list, code, params)
+        {rating_detail_list, review.rating_option_vote.rating_option.value + rating_sum}
+      end)
+
+    rating_percent_list =
+      Enum.map(rating_detail, fn {code, params} ->
+        {code, %{params | value: params.value / count * 100}}
+      end)
+
+    %{
+      review_detail
+      | average_rating: sum |> Decimal.div(count) |> Decimal.round(1),
+        review_count: count,
+        rating_summary: rating_percent_list
+    }
+  end
+
+  defp get_rating_value(nil), do: nil
+  defp get_rating_value(rating_data), do: Map.get(rating_data, :value)
+
+  defp parse_review_params(params) do
+    %{attributes: review_params} = params
+    %{rating_option_vote: %{rating_option: rating_option}} = params
+    Map.put(review_params, :rating_option_vote, %{rating_option: rating_option})
+  end
+
+  def fetch_rating_option(id) do
+    QH.get(RatingOption, id, Repo)
+  end
+
+  def persist(multi) do
+    case Repo.transaction(multi) do
+      {:ok, %{review: review}} ->
+        {:ok, review}
+
+      {:error, _, error_value, _} ->
+        {:error, error_value}
+    end
+  end
+end

--- a/apps/snitch_core/lib/core/data/model/rating.ex
+++ b/apps/snitch_core/lib/core/data/model/rating.ex
@@ -1,0 +1,29 @@
+defmodule Snitch.Data.Model.Rating do
+  @moduledoc """
+  APIs for rating
+  """
+
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.{Rating, RatingOption}
+
+  @doc """
+  Returns all the ratings.
+  """
+  @spec get_all() :: [Rating.t()]
+  def get_all do
+    Repo.all(Rating)
+  end
+
+  @doc """
+  Returns a `rating` by the supplied `id`.
+  """
+  @spec get(non_neg_integer) :: Rating.t() | nil
+  def get(id) do
+    QH.get(Rating, id, Repo)
+  end
+
+  @spec get_rating_option(non_neg_integer) :: RatingOption.t() | nil
+  def get_rating_option(id) do
+    QH.get(RatingOption, id, Repo)
+  end
+end

--- a/apps/snitch_core/lib/core/data/model/review.ex
+++ b/apps/snitch_core/lib/core/data/model/review.ex
@@ -1,0 +1,51 @@
+defmodule Snitch.Data.Model.Review do
+  @moduledoc """
+  APIs for Review.
+  """
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.Review
+
+  @doc """
+  Udpates a `review` with supplied `params`.
+
+  To update the `rating_option_vote` this `review`
+  has, a `rating_option` struct is expected under the
+  `:rating_option` key nested inside the `review_option_vote`
+  key.
+
+  ## Example
+    params = %{
+      description: "modified from earlier"
+      rating_option_vote: %{
+        rating_option: %RatingOption{
+          code: "1", position: 1, value: 1
+        }
+      }
+    }
+  """
+
+  @spec update(map, Review.t()) ::
+          {:ok, Review.t()}
+          | {:error, Ecto.Changeset.t()}
+  def update(params, review) do
+    QH.update(Review, params, review, Repo)
+  end
+
+  @doc """
+  Deletes a `review` for supplied `id`.
+  """
+  @spec delete(Review.t()) ::
+          {:ok, Review.t()}
+          | {:error, Ecto.Changeset.t()}
+  def delete(id) do
+    QH.delete(Review, id, Repo)
+  end
+
+  @doc """
+  Returns a review for the supplied `id`
+  """
+  @spec get(non_neg_integer) :: Review.t() :: nil
+  def get(id) do
+    QH.get(Review, id, Repo)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -5,6 +5,7 @@ defmodule Snitch.Data.Schema.Product do
 
   use Snitch.Data.Schema
   alias Snitch.Data.Schema.Product.NameSlug
+  alias Snitch.Data.Schema.Review
   alias Snitch.Data.Schema.Variant
 
   @type t :: %__MODULE__{}
@@ -22,13 +23,24 @@ defmodule Snitch.Data.Schema.Product do
     field(:promotionable, :boolean)
     timestamps()
 
+    # associations
     has_many(:variants, Variant)
+    many_to_many(:reviews, Review, join_through: "snitch_product_reviews")
   end
 
   @required_fields ~w(name)a
-  @optional_fields ~w(description meta_description meta_keywords meta_title)a
+  @optional_fields ~w(description meta_description meta_keywords
+    meta_title average_rating review_count)a
 
   def changeset(model, params \\ %{}) do
+    common_changeset(model, params)
+  end
+
+  def update_changeset(%__MODULE__{} = product, params) do
+    common_changeset(product, params)
+  end
+
+  def common_changeset(model, params) do
     model
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)

--- a/apps/snitch_core/lib/core/data/schema/rating/rating.ex
+++ b/apps/snitch_core/lib/core/data/schema/rating/rating.ex
@@ -1,0 +1,53 @@
+defmodule Snitch.Data.Schema.Rating do
+  @moduledoc """
+  Models a Rating.
+
+  `rating` define the different types of enities
+  for which a rating can be given.
+
+  The `code` field represents the entity
+  e.g. a ratings for products has the code as "product".
+  The position `field` is just a helper for the sequence in which
+  the `ratings` would be shown.
+
+  It is used to identify the `rating_options` for a
+  particular `entity`.
+  ## See
+  `Snitch.Data.Schema.RatingOption`
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.RatingOption
+  @type t :: %__MODULE__{}
+
+  schema "snitch_ratings" do
+    field(:code, :string)
+    field(:position, :integer)
+
+    has_many(:rating_options, RatingOption)
+    timestamps()
+  end
+
+  @doc """
+  Returns a create changeset for `rating`.
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = rating, params) do
+    common_changeset(rating, params)
+  end
+
+  @doc """
+  Returns an update changeset for `rating`.
+  """
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = rating, params) do
+    common_changeset(rating, params)
+  end
+
+  defp common_changeset(rating, params) do
+    rating
+    |> cast(params, [:code, :position])
+    |> validate_required(:code)
+    |> unique_constraint(:code)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/rating/rating_option.ex
+++ b/apps/snitch_core/lib/core/data/schema/rating/rating_option.ex
@@ -1,0 +1,52 @@
+defmodule Snitch.Data.Schema.RatingOption do
+  @moduledoc """
+  Models a Rating Option.
+
+  `rating_options` allow to create different types
+  of `options` for a `rating` type.
+  e.g.
+  For a `rating` of type "product" there can be rating
+  options as:
+  [{"1", 1, 1}, {"2", 2, 2}, {"3", 3, 3}, {"4", 4, 4}, {"5", 5, 5}]
+  which is basically the format [{code, value, position}]
+  This allows a product to be given a rating from 1 to 5.
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.Rating
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_rating_options" do
+    field(:code, :string, null: false)
+    field(:value, :integer, null: false)
+    field(:position, :integer, null: false)
+
+    belongs_to(:rating, Rating)
+
+    timestamps()
+  end
+
+  @required_fields ~w(code value position rating_id)a
+  @update_fields ~w(position code)a
+
+  @doc """
+  Returns a create changeset for rating option.
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = rating_option, params) do
+    rating_option
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+  end
+
+  @doc """
+  Returns a create changeset for rating option.
+  """
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = rating_option, params) do
+    rating_option
+    |> cast(params, @update_fields)
+    |> validate_required(@update_fields)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/rating/rating_option_vote.ex
+++ b/apps/snitch_core/lib/core/data/schema/rating/rating_option_vote.ex
@@ -1,0 +1,42 @@
+defmodule Snitch.Data.Schema.RatingOptionVote do
+  @moduledoc """
+  Models Rating option vote.
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.RatingOption
+  alias Snitch.Data.Schema.Review
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_rating_option_votes" do
+    ## TODO check the viablility of these fields
+    # field(:value, :string)
+    # field(:percent, :string)
+
+    belongs_to(:rating_option, RatingOption)
+    belongs_to(:review, Review)
+
+    timestamps()
+  end
+
+  @doc """
+  Returns a create changeset for rating option vote.
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = rating_option_vote, params) do
+    rating_option_vote
+    |> cast(params, [])
+    |> put_assoc(:rating_option, params[:rating_option])
+  end
+
+  @doc """
+  Returns an update changeset for rating option vote.
+  """
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = rating_option_vote, params) do
+    rating_option_vote
+    |> cast(params, [])
+    |> put_assoc(:rating_option, params)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/review/product_review.ex
+++ b/apps/snitch_core/lib/core/data/schema/review/product_review.ex
@@ -1,0 +1,38 @@
+defmodule Snitch.Data.Schema.ProductReview do
+  @moduledoc """
+  Models product review.
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.Product
+  alias Snitch.Data.Schema.Review
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_product_reviews" do
+    belongs_to(:product, Product)
+    belongs_to(:review, Review)
+
+    timestamps()
+  end
+
+  @required_params ~w(product_id review_id)a
+
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = product_review, params) do
+    common_changeset(product_review, params)
+  end
+
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = product_review, params) do
+    common_changeset(product_review, params)
+  end
+
+  defp common_changeset(product_review, params) do
+    product_review
+    |> cast(params, @required_params)
+    |> validate_required(@required_params)
+    |> foreign_key_constraint(:product_id)
+    |> foreign_key_constraint(:review_id)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/review/review.ex
+++ b/apps/snitch_core/lib/core/data/schema/review/review.ex
@@ -1,0 +1,67 @@
+defmodule Snitch.Data.Schema.Review do
+  @moduledoc """
+  Models Reviews.
+
+  Reviews represent customer feedback for any entity in the
+  e-commerce. Reviews can be given for any service so it
+  has to be generic.
+
+  `reviews` has_one `rating_option_vote`.
+  ## See
+  `Snitch.Data.Schema.RatingOptionVote`
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.RatingOptionVote
+  alias Snitch.Data.Schema.User
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_reviews" do
+    field(:title, :string)
+    field(:description, :string)
+    field(:approved, :boolean, default: false)
+    field(:locale, :string)
+    field(:name, :string)
+
+    # associations
+    belongs_to(:user, User)
+    has_one(:rating_option_vote, RatingOptionVote, on_replace: :delete)
+
+    timestamps()
+  end
+
+  @required_params ~w(description user_id name)a
+  @optional_params ~w(title locale approved)a
+
+  @create_params @required_params ++ @optional_params
+  @update_params ~w(description)a ++ @optional_params
+
+  @doc """
+  Returns a product review changeset.
+  """
+  @spec create_changeset(t, map) :: Ecto.Changeset.t()
+  def create_changeset(%__MODULE__{} = review, params) do
+    review
+    |> cast(params, @create_params)
+    |> common_changeset()
+  end
+
+  @spec update_changeset(t, map) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = review, params) do
+    review
+    |> cast(params, @update_params)
+    |> common_changeset()
+  end
+
+  defp common_changeset(changeset) do
+    changeset
+    |> validate_required(@required_params)
+    |> foreign_key_constraint(:user_id)
+    |> cast_assoc(
+      :rating_option_vote,
+      required: true,
+      with: &RatingOptionVote.create_changeset/2
+    )
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180709122928_add_rating_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180709122928_add_rating_table.exs
@@ -1,0 +1,14 @@
+defmodule Snitch.Repo.Migrations.AddRatingTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_ratings) do
+      add(:code, :string, null: false)
+      add(:position, :integer, default: 0, null: false)
+
+      timestamps()
+    end
+
+    create unique_index(:snitch_ratings, :code)
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180709125602_add_rating_option_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180709125602_add_rating_option_table.exs
@@ -1,0 +1,14 @@
+defmodule Snitch.Repo.Migrations.AddRatingOptionTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_rating_options) do
+      add(:code, :string, null: false)
+      add(:value, :integer, null: false)
+      add(:position, :integer, default: 0, null: false)
+      add(:rating_id, references(:snitch_ratings, on_delete: :delete_all))
+
+      timestamps()
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180712074310_add_reviews_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180712074310_add_reviews_table.exs
@@ -1,0 +1,16 @@
+defmodule Snitch.Repo.Migrations.AddReviewsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_reviews) do
+      add(:title, :string)
+      add(:description, :string, null: false)
+      add(:approved, :boolean, default: false)
+      add(:locale, :string)
+      add(:name, :string, null: false)
+      add(:user_id, references(:snitch_users, on_delete: :restrict), null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180712074637_add_product_review_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180712074637_add_product_review_table.exs
@@ -1,0 +1,12 @@
+defmodule Snitch.Repo.Migrations.AddProductReviewTable do
+  use Ecto.Migration
+
+  def change do
+    create table("snitch_product_reviews") do
+      add(:product_id, references(:snitch_products, on_delete: :delete_all), null: false)
+      add(:review_id, references(:snitch_reviews, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20180712075441_add_rating_option_vote_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20180712075441_add_rating_option_vote_table.exs
@@ -1,0 +1,12 @@
+defmodule Snitch.Repo.Migrations.AddRatingOptionVote do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_rating_option_votes) do
+      add(:rating_option_id, references(:snitch_rating_options), null: false)
+      add(:review_id, references(:snitch_reviews, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/product_rating.ex
+++ b/apps/snitch_core/priv/repo/seed/product_rating.ex
@@ -1,0 +1,38 @@
+defmodule Snitch.Seed.ProductRating do
+  @moduledoc """
+  Seed file for product rating and rating options.
+  """
+
+  alias Snitch.Repo
+  alias Snitch.Data.Schema.Rating
+  alias Snitch.Data.Schema.RatingOption
+
+  require Logger
+
+  @product_rating_options [{1, "1", 1}, {2, "2", 2}, {3, "3", 3}, {4, "4", 4}, {5, "5", 5}]
+
+  def seed do
+    Repo.transaction(fn ->
+      rating = Repo.insert!(%Rating{code: "product"})
+      Logger.info("Inserted rating type product!")
+      seed_prodcut_rating_options(rating)
+    end)
+  end
+
+  def seed_prodcut_rating_options(rating) do
+    options =
+      Enum.map(@product_rating_options, fn {value, code, position} ->
+        %{
+          code: code,
+          value: value,
+          position: position,
+          rating_id: rating.id,
+          inserted_at: Ecto.DateTime.utc(),
+          updated_at: Ecto.DateTime.utc()
+        }
+      end)
+
+    Repo.insert_all(RatingOption, options)
+    Logger.info("Inserted rating options for product!")
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/roles_seed.ex
+++ b/apps/snitch_core/priv/repo/seed/roles_seed.ex
@@ -5,6 +5,8 @@ defmodule Snitch.Seed.Role do
   alias Snitch.Data.Schema.Role
   alias Snitch.Repo
 
+  require Logger
+
   def seed do
     data =
       Enum.reduce(@roles, [], fn {role, description}, acc ->
@@ -18,6 +20,7 @@ defmodule Snitch.Seed.Role do
         [value | acc]
       end)
 
-    Repo.insert_all(Role, data, on_conflict: :nothing, conflict_target: :name)
+    {count, _} = Repo.insert_all(Role, data, on_conflict: :nothing, conflict_target: :name)
+    Logger.info("Inserted #{count} roles")
   end
 end

--- a/apps/snitch_core/priv/repo/seed/seeds.exs
+++ b/apps/snitch_core/priv/repo/seed/seeds.exs
@@ -21,7 +21,8 @@ alias Snitch.Seed.{
   Taxonomy,
   Role,
   Shipping,
-  Product
+  Product,
+  ProductRating
 }
 
 variant_count = 9
@@ -55,3 +56,6 @@ Role.seed()
 
 # seed products
 Product.seed()
+
+# seeds a product rating and it's types
+ProductRating.seed()

--- a/apps/snitch_core/test/data/model/product_review_test.exs
+++ b/apps/snitch_core/test/data/model/product_review_test.exs
@@ -1,0 +1,71 @@
+defmodule Snitch.Data.Model.ProductReviewTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Data.Model.ProductReview
+
+  setup do
+    product = insert(:product)
+    [product: product]
+  end
+
+  setup :rating_options
+
+  @tag rating_option_count: 1
+  test "create product review successfully", context do
+    %{product: product} = context
+    user = insert(:user)
+    %{rating_options: rating_options} = context
+    rating_option = List.first(rating_options)
+    review_params = product_review_params(product, user, rating_option)
+    assert {:ok, _} = ProductReview.add(review_params)
+    product = Repo.preload(product, :reviews)
+    assert length(product.reviews) != 0
+  end
+
+  @tag rating_option_count: 1
+  test "creation fails for invalid params", context do
+    %{product: product} = context
+    user = %{id: -1}
+    %{rating_options: rating_options} = context
+    rating_option = List.first(rating_options)
+    review_params = product_review_params(product, user, rating_option)
+    assert {:error, changeset} = ProductReview.add(review_params)
+    assert %{user_id: ["does not exist"]} = errors_on(changeset)
+  end
+
+  @tag rating_option_count: 2
+  test "get rating aggregate for a product", context do
+    %{product: product} = context
+    user1 = insert(:user)
+    user2 = insert(:user, role: %{name: "user"})
+    %{rating_options: rating_options} = context
+
+    [rating_option_1 | [rating_option_2 | _]] = rating_options
+    review_params = product_review_params(product, user1, rating_option_1)
+    assert {:ok, _} = ProductReview.add(review_params)
+    review_params = product_review_params(product, user2, rating_option_2)
+    assert {:ok, _} = ProductReview.add(review_params)
+    result = ProductReview.review_aggregate(product)
+
+    assert result.average_rating ==
+             Decimal.div(rating_option_1.value + rating_option_2.value, 2)
+             |> Decimal.round(1)
+
+    assert result.review_count == 2
+  end
+
+  defp product_review_params(product, user, rating_option) do
+    %{
+      attributes: %{
+        description: "awesomeness redefined",
+        user_id: user.id,
+        name: "stark"
+      },
+      rating_option_vote: %{
+        rating_option: rating_option
+      },
+      product_id: product.id
+    }
+  end
+end

--- a/apps/snitch_core/test/data/model/review_test.exs
+++ b/apps/snitch_core/test/data/model/review_test.exs
@@ -1,0 +1,62 @@
+defmodule Snitch.Data.Model.ReviewTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+  alias Snitch.Data.Model.{Review, ProductReview}
+
+  setup do
+    product = insert(:product)
+    [product: product]
+  end
+
+  setup :rating_options
+
+  @tag rating_option_count: 2
+  test "update a review successfully", context do
+    %{product: product} = context
+    user = insert(:user)
+    %{rating_options: rating_options} = context
+    [rating_option_1 | [rating_option_2 | _]] = rating_options
+    review_params = product_review_params(product, user, rating_option_1)
+    assert {:ok, review} = ProductReview.add(review_params)
+
+    update_params = %{
+      description: "new description",
+      rating_option_vote: %{rating_option: rating_option_2}
+    }
+
+    assert {:ok, updated_review} = Review.update(update_params, review)
+    assert updated_review.id == review.id
+    assert updated_review.description != review.description
+  end
+
+  @tag rating_option_count: 1
+  test "delete a product review", context do
+    %{product: product} = context
+    user = insert(:user)
+    %{rating_options: rating_options} = context
+    rating_option = List.first(rating_options)
+    review_params = product_review_params(product, user, rating_option)
+    assert {:ok, review} = ProductReview.add(review_params)
+    product_before_delete = Repo.preload(product, :reviews)
+    assert length(product_before_delete.reviews) != 0
+    assert {:ok, _} = Review.delete(review.id)
+    product_after_delete = Repo.preload(product, :reviews)
+    assert product_after_delete.reviews == []
+  end
+
+  defp product_review_params(product, user, rating_option) do
+    %{
+      attributes: %{
+        description: "awesomeness redefined",
+        user_id: user.id,
+        name: "stark"
+      },
+      rating_option_vote: %{
+        rating_option: rating_option
+      },
+      product_id: product.id
+    }
+  end
+end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -2,7 +2,7 @@ defmodule Snitch.Factory do
   @moduledoc false
 
   use ExMachina.Ecto, repo: Snitch.Repo
-  use Snitch.Factory.{Address, Shipping, Stock, Taxonomy, Zone}
+  use Snitch.Factory.{Address, Shipping, Stock, Taxonomy, Zone, Rating}
 
   alias Snitch.Data.Schema.{
     Address,
@@ -10,14 +10,15 @@ defmodule Snitch.Factory do
     CardPayment,
     LineItem,
     Order,
-    Permission,
     Payment,
     PaymentMethod,
+    Permission,
     Role,
     TaxCategory,
     TaxRate,
     User,
-    Variant
+    Variant,
+    Product
   }
 
   alias Snitch.Repo
@@ -136,7 +137,7 @@ defmodule Snitch.Factory do
 
   def tax_category_factory do
     %TaxCategory{
-      name: sequence(:name, ["CE_VAT", "GST", "CGST", "AU_VAT"]),
+      name: sequence(:tax_category, ["CE_VAT", "GST", "CGST", "AU_VAT"]),
       description: "tax applied",
       is_default?: false,
       tax_code: sequence(:tax_code, ["CE_1", "GST", "CGST", "AU_VAT"]),
@@ -150,7 +151,7 @@ defmodule Snitch.Factory do
 
   def tax_rate_factory do
     %TaxRate{
-      name: sequence(:name, ["North America", "Europe", "India", "China"]),
+      name: sequence(:tax_region, ["North America", "Europe", "India", "China"]),
       value: 0.5,
       included_in_price: false,
       calculator: Snitch.Domain.Calculator.Default
@@ -168,6 +169,14 @@ defmodule Snitch.Factory do
     %Permission{
       code: sequence(:code, ["manage_products", "manage_orders", "manage_all"]),
       description: "can manage respective"
+    }
+  end
+
+  def product_factory do
+    %Product{
+      name: sequence(:product, &"shoes-nike-#{&1}"),
+      description: "awesome products",
+      slug: sequence(:slug, &"nike-#{&1}")
     }
   end
 

--- a/apps/snitch_core/test/support/factory/rating.ex
+++ b/apps/snitch_core/test/support/factory/rating.ex
@@ -1,0 +1,31 @@
+defmodule Snitch.Factory.Rating do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Snitch.Data.Schema.{Rating, RatingOption}
+
+      def rating_factory do
+        %Rating{
+          code: "product",
+          position: 0
+        }
+      end
+
+      def rating_option_factory do
+        %RatingOption{
+          rating: build(:rating),
+          code: sequence(:code, ["1", "2", "3"]),
+          value: sequence(:value, [1, 2, 3]),
+          position: sequence(:position, [1, 2, 3])
+        }
+      end
+
+      def rating_options(context) do
+        rating = insert(:rating)
+        count = Map.get(context, :rating_option_count, 2)
+        [rating_options: insert_list(3, :rating_option, rating: rating)]
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
Reviews and ratings are a great tool widely used in e-commerce. It's an important mechanism for
obtaining customer feedback.
## Describe your changes
<!--- List and detail all changes made in this PR. -->
### Reviews and Ratings
The PR adds a mechanism to add reviews and ratings. The database design for the feature has been such that review and ratings can be given for various entities.
e.g. feedback on products, feedback on delivery service etc.

__Ratings and RatingOptions__
Rating in general refers to a qualitative feedback, coomonly seen as number of stars in e-commerce.

- The rating table contains info about the entity for which we want to give a review e.g. "product".
- A rating can have different rating options.e.g. "product" can have rating options from 1star to 5 star whereas for any other service it can be from 1star to 10. This info is kept in rating options table.
```
Rating ----> has many --> RatingOptions
```
__Review__
Review is for textual feedback where user describes the review.

- The review table stores the description entered by the user.
- The review is usually associated with a rating.
- The association here is done with help of `rating option votes` table. The `rating_option_vote` creates an association between `rating_options` and the `review`.

```
Review --> has one ---> RatingOptionVote
``` 

Since review can be for different entiites it has a polymorphic association with them. The association is being taken care of by using middle tables.
So in case of product_reviews it is of the form
```
product --> has_many ---> Reviews, through ---> ProductReviews
```
For now, to  calculate `average rating` and `review counts` for a product we are performing some calculations, but it has been planned to keep them in a separate table in future iterations.

## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
