### PR TITLE
User registration and sigin/signout/signup

### DIFF
--- a/apps/snitch_api/config/config.exs
+++ b/apps/snitch_api/config/config.exs
@@ -28,6 +28,10 @@ config :mime, :types, %{
 # Configures Key Format
 config :ja_serializer, key_format: :underscored
 
+config :snitch_api, SnitchApi.Guardian,
+  issuer: "snitch_api",
+  secret_key: "V4h+IQskKPefHzO58nDlKRz/ZAWZ1KpM2PBt0Tp3ozexHDE8JQ4dkwblH7PZvZOm"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/apps/snitch_api/lib/snitch_api/accounts/accounts.ex
+++ b/apps/snitch_api/lib/snitch_api/accounts/accounts.ex
@@ -1,0 +1,91 @@
+defmodule SnitchApi.Accounts do
+  alias Snitch.Data.Model.Role, as: RoleModel
+  alias Snitch.Data.Schema.User
+  alias Snitch.Domain.Account
+  alias Snitch.Repo
+  alias SnitchApi.Guardian
+
+  @moduledoc """
+  The Accounts context.
+  """
+
+  @doc """
+  Returns the list of users.
+
+  ## Examples
+
+      iex> list_users()
+      [%User{}, ...]
+
+  """
+  def list_users do
+    raise "TODO"
+  end
+
+  @doc """
+  Gets a single user.
+
+  Raises if the User does not exist.
+
+  ## Examples
+
+      iex> get_user!(123)
+      %User{}
+
+  """
+  def get_user!(id), do: Repo.get!(User, id)
+
+  @doc """
+  Creates a user.
+
+  ## Examples
+
+      iex> create_user(%{field: value})
+      {:ok, %User{}}
+
+      iex> create_user(%{field: bad_value})
+      {:error, ...}
+
+  """
+  def create_user(attrs \\ %{}) do
+    role_id =
+      "user"
+      |> RoleModel.get_role_by_name()
+      |> Map.get(:id)
+
+    attrs
+    |> Map.put("role_id", role_id)
+    |> Account.register()
+  end
+
+  def token_sign_in(email, password) do
+    case Account.authenticate(email, password) do
+      {:ok, user} ->
+        user = Snitch.Repo.preload(user, [:role])
+        Guardian.encode_and_sign(user, %{}, ttl: {10, :minute})
+
+      _ ->
+        {:error, :unauthorized}
+    end
+  end
+
+  def resource_from_token(token) do
+    case Guardian.resource_from_token(token) do
+      {:ok, resource, _claims} ->
+        resource
+
+      {:error, :token_expired} ->
+        :expired
+    end
+  end
+
+  def refresh_token(token) do
+    {:ok, _old_stuff, {new_token, new_claims}} = Guardian.refresh(token)
+    {new_token, new_claims}
+  end
+
+  # checks the validity of the token
+  def verify_token(token) do
+    Guardian.decode_and_verify(token)
+  end
+end

--- a/apps/snitch_api/lib/snitch_api/auth_handler.ex
+++ b/apps/snitch_api/lib/snitch_api/auth_handler.ex
@@ -1,0 +1,8 @@
+defmodule SnitchApi.AuthErrorHandler do
+  import Plug.Conn
+
+  def auth_error(conn, {type, _reason}, _opts) do
+    body = Poison.encode!(%{error: to_string(type)})
+    send_resp(conn, 403, body)
+  end
+end

--- a/apps/snitch_api/lib/snitch_api/guardian.ex
+++ b/apps/snitch_api/lib/snitch_api/guardian.ex
@@ -1,0 +1,21 @@
+defmodule SnitchApi.Guardian do
+  use Guardian, otp_app: :snitch_api
+
+  def subject_for_token(user, _claims) do
+    sub = to_string(user.id)
+    {:ok, sub}
+  end
+
+  def subject_for_token(_, _) do
+    {:error, :reason_for_error}
+  end
+
+  def resource_from_claims(%{"sub" => id}) do
+    resource = SnitchApi.Accounts.get_user!(id)
+    {:ok, resource}
+  end
+
+  def resource_from_claims(_claims) do
+    {:error, :reason_for_error}
+  end
+end

--- a/apps/snitch_api/lib/snitch_api_web/api_pipeline.ex
+++ b/apps/snitch_api/lib/snitch_api_web/api_pipeline.ex
@@ -1,0 +1,17 @@
+defmodule SnitchApiWeb.Guardian.AuthPipeline do
+  use Guardian.Plug.Pipeline,
+    otp_app: :snitch_api,
+    module: SnitchApi.Guardian,
+    error_handler: SnitchApi.AuthErrorHandler
+
+  plug(Guardian.Plug.VerifyHeader, realm: "Bearer")
+  plug(Guardian.Plug.EnsureAuthenticated)
+  plug(Guardian.Plug.LoadResource)
+
+  # If there is a session token, restrict it to an access token and validate it
+  plug(Guardian.Plug.VerifySession, claims: %{"typ" => "access"})
+  # If there is an authorization header, restrict it to an access token and validate it
+  plug(Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"})
+  # Load the user if either of the verifications worked
+  plug(Guardian.Plug.LoadResource, allow_blank: true)
+end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/fallback_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/fallback_controller.ex
@@ -1,0 +1,32 @@
+defmodule SnitchApiWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use SnitchApiWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(SnitchApiWeb.ChangesetView, "error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> render(SnitchApiWeb.ErrorView, :"404")
+  end
+
+  def call(conn, {:error, :unauthorized}) do
+    conn
+    |> put_status(:not_found)
+    |> render(SnitchApiWeb.ErrorView, :unauthorized)
+  end
+
+  def call(conn, {:error, :no_credentials}) do
+    conn
+    |> put_status(:not_found)
+    |> render(SnitchApiWeb.ErrorView, :no_credentials)
+  end
+end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -5,6 +5,10 @@ defmodule SnitchApiWeb.OrderController do
   alias Snitch.Data.Schema.Order
   alias Snitch.Repo
 
+  action_fallback(SnitchApiWeb.FallbackController)
+  plug(SnitchApiWeb.Plug.DataToAttributes)
+  plug(SnitchApiWeb.Plug.LoadUser)
+
   def index(conn, params) do
     orders = Repo.preload(OrderModel.get_all(), :line_items)
 

--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxon_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxon_controller.ex
@@ -4,6 +4,11 @@ defmodule SnitchApiWeb.TaxonController do
   alias Snitch.Data.Schema.Taxon
   alias Snitch.Repo
 
+  action_fallback(SnitchApiWeb.FallbackController)
+
+  plug(SnitchApiWeb.Plug.DataToAttributes)
+  plug(SnitchApiWeb.Plug.LoadUser)
+
   def index(conn, _params) do
     taxons =
       Taxon
@@ -14,7 +19,7 @@ defmodule SnitchApiWeb.TaxonController do
       conn,
       "index.json-api",
       data: taxons,
-      opts: [include: "parent"]
+      opts: [include: "parent,taxonomy"]
     )
   end
 

--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
@@ -4,6 +4,10 @@ defmodule SnitchApiWeb.TaxonomyController do
   alias Snitch.Data.Schema.Taxonomy
   alias Snitch.Repo
 
+  action_fallback(SnitchApiWeb.FallbackController)
+  plug(SnitchApiWeb.Plug.DataToAttributes)
+  plug(SnitchApiWeb.Plug.LoadUser)
+
   def index(conn, _params) do
     taxonomies =
       Taxonomy

--- a/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
@@ -1,0 +1,57 @@
+defmodule SnitchApiWeb.UserController do
+  use SnitchApiWeb, :controller
+
+  alias Snitch.Data.Schema.User
+  alias SnitchApi.Accounts
+  alias SnitchApi.Guardian
+
+  plug(SnitchApiWeb.Plug.DataToAttributes)
+  plug(SnitchApiWeb.Plug.LoadUser)
+
+  action_fallback(SnitchApiWeb.FallbackController)
+
+  def index(conn, _params) do
+    users = Accounts.list_users()
+    render(conn, "index.json-api", users: users)
+  end
+
+  def create(conn, params) do
+    with {:ok, %User{} = user} <- Accounts.create_user(params) do
+      conn
+      |> put_status(200)
+      |> put_resp_header("location", user_path(conn, :show, user))
+      |> render("show.json-api", data: user)
+    end
+  end
+
+  def login(conn, %{"email" => email, "password" => password}) do
+    case Accounts.token_sign_in(email, password) do
+      {:ok, token, _claims} ->
+        render(conn, "token.json-api", data: token)
+
+      _ ->
+        {:error, :unauthorized}
+    end
+  end
+
+  def login(_conn, _params) do
+    {:error, :no_credentials}
+  end
+
+  def show(conn, %{"id" => id}) do
+    user = Accounts.get_user!(id)
+    render(conn, "show.json-api", data: user)
+  end
+
+  def logout(conn, _params) do
+    conn
+    |> Guardian.Plug.sign_out()
+    |> put_status(204)
+    |> render("logout.json-api", data: "logged out")
+  end
+
+  def current_user(conn, _params) do
+    user = Guardian.Plug.current_resource(conn)
+    render(conn, "current_user.json-api", data: user)
+  end
+end

--- a/apps/snitch_api/lib/snitch_api_web/plugs/data_to_attributes.ex
+++ b/apps/snitch_api/lib/snitch_api_web/plugs/data_to_attributes.ex
@@ -1,0 +1,57 @@
+defmodule SnitchApiWeb.Plug.DataToAttributes do
+  import Inflex, only: [pluralize: 1]
+
+  @moduledoc ~S"""
+  Converts params in the JSON api format into flat params convient for
+  changeset casting.
+
+  For base parameters, this is done using `JaSerializer.Params.to_attributes/1`
+
+  For included records, this is done using custom code.
+  """
+
+  alias Plug.Conn
+
+  @spec init(Keyword.t()) :: Keyword.t()
+  def init(opts), do: opts
+
+  @spec call(Conn.t(), Keyword.t()) :: Plug.Conn.t()
+  def call(%Conn{params: %{} = params} = conn, opts \\ []) do
+    attributes =
+      params
+      |> Map.delete("data")
+      |> Map.delete("included")
+      |> Map.merge(params |> parse_data())
+      |> Map.merge(params |> parse_included(opts))
+
+    conn |> Map.put(:params, attributes)
+  end
+
+  @spec parse_data(map) :: map
+  defp parse_data(%{"data" => data}), do: data |> JaSerializer.Params.to_attributes()
+  defp parse_data(%{}), do: %{}
+
+  @spec parse_included(map, Keyword.t()) :: map
+  defp parse_included(%{"included" => included}, opts) do
+    included
+    |> Enum.reduce(%{}, fn %{"data" => %{"type" => type}} = params, parsed ->
+      attributes = params |> parse_data()
+
+      if opts |> Keyword.get(:includes_many, []) |> Enum.member?(type) do
+        # this is an explicitly specified has_many,
+        # update existing data by adding new record
+        pluralized_type = type |> Inflex.pluralize()
+
+        parsed
+        |> Map.update(pluralized_type, [attributes], fn data ->
+          data ++ [attributes]
+        end)
+      else
+        # this is a belongs to, put a new submap into payload
+        parsed |> Map.put(type, attributes)
+      end
+    end)
+  end
+
+  defp parse_included(%{}, _opts), do: %{}
+end

--- a/apps/snitch_api/lib/snitch_api_web/plugs/load_user.ex
+++ b/apps/snitch_api/lib/snitch_api_web/plugs/load_user.ex
@@ -1,0 +1,11 @@
+defmodule SnitchApiWeb.Plug.LoadUser do
+  import Plug.Conn
+  import SnitchApi.Guardian
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    user = Guardian.Plug.current_resource(conn)
+    assign(conn, :current_user, user)
+  end
+end

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -1,17 +1,33 @@
 defmodule SnitchApiWeb.Router do
   use SnitchApiWeb, :router
 
+  alias SnitchApiWeb.Guardian
+
   pipeline :api do
     plug(:accepts, ["json-api", "json"])
     plug(JaSerializer.Deserializer)
   end
 
+  pipeline :authenticated do
+    plug(Guardian.AuthPipeline)
+  end
+
   scope "/api/v1", SnitchApiWeb do
     pipe_through(:api)
-
-    resources("/orders", OrderController, only: [:index, :show])
+    # user sign_in_up
+    post("/register", UserController, :create)
+    post("/login", UserController, :login)
     post("/orders/blank", OrderController, :guest_order)
+  end
 
+  scope "/api/v1", SnitchApiWeb do
+    pipe_through([:api, :authenticated])
+
+    # user sign_in_out_up
+    get("/users/:id", UserController, :show)
+    post("/logout", UserController, :logout)
+    get("/current_user", UserController, :current_user)
+    resources("/orders", OrderController, only: [:index, :show])
     resources("/taxonomies", TaxonomyController, only: [:index, :show])
     resources("/taxons", TaxonController, only: [:index, :show])
   end

--- a/apps/snitch_api/lib/snitch_api_web/views/changeset_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/changeset_view.ex
@@ -1,0 +1,18 @@
+defmodule SnitchApiWeb.ChangesetView do
+  use SnitchApiWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+  See `Ecto.Changeset.traverse_errors/2` and
+  `SnitchApiWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/apps/snitch_api/lib/snitch_api_web/views/error_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/error_view.ex
@@ -1,11 +1,23 @@
 defmodule SnitchApiWeb.ErrorView do
   use SnitchApiWeb, :view
 
-  def render("404.json", _assigns) do
+  def render("404.json-api", _assigns) do
     %{errors: %{detail: "Page not found"}}
   end
 
-  def render("500.json", _assigns) do
+  def render("unauthorized.json-api", _assigns) do
+    %{errors: %{detail: "un_authorized"}}
+  end
+
+  def render("no_credentials.json-api", _assigns) do
+    %{errors: %{detail: "no login credentials"}}
+  end
+
+  def render("500.json-api", _assigns) do
+    %{errors: %{detail: "Internal server error"}}
+  end
+
+  def render("505.json-api", _assigns) do
     %{errors: %{detail: "Internal server error"}}
   end
 

--- a/apps/snitch_api/lib/snitch_api_web/views/user_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/user_view.ex
@@ -4,5 +4,24 @@ defmodule SnitchApiWeb.UserView do
 
   location("/users/:id")
 
-  attributes([:id, :name])
+  attributes([:name, :email])
+
+  def name(user, _conn) do
+    user
+    |> Map.take([:first_name, :last_name])
+    |> Map.values()
+    |> List.to_string()
+  end
+
+  def render("token.json-api", %{data: token}) do
+    %{token: token}
+  end
+
+  def render("logout.json-api", %{data: status}) do
+    %{status: status}
+  end
+
+  def render("current_user.json-api", %{data: user}) do
+    %{data: Map.take(user, [:email, :first_name, :last_name, :id])}
+  end
 end

--- a/apps/snitch_api/mix.exs
+++ b/apps/snitch_api/mix.exs
@@ -45,7 +45,11 @@ defmodule SnitchApi.Mixfile do
       {:corsica, "~> 1.0"},
       {:uuid, "~> 1.1"},
       {:ja_serializer, "~> 0.13.0"},
-      {:recase, "~> 0.2"}
+      {:recase, "~> 0.2"},
+
+      # Authentication
+      {:guardian, "~> 1.0"},
+      {:inflex, "~> 1.10.0"}
     ]
   end
 end

--- a/apps/snitch_api/test/snitch_api/accounts/accounts_test.exs
+++ b/apps/snitch_api/test/snitch_api/accounts/accounts_test.exs
@@ -1,0 +1,3 @@
+defmodule SnitchApi.AccountsTest do
+  use ExUnit.Case
+end

--- a/apps/snitch_api/test/snitch_api/api/api_test.exs
+++ b/apps/snitch_api/test/snitch_api/api/api_test.exs
@@ -1,0 +1,3 @@
+defmodule SnitchApi.APITest do
+  use SnitchApiWeb.ConnCase, async: true
+end

--- a/apps/snitch_api/test/snitch_api_web/controllers/taxonomy_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/taxonomy_controller_test.exs
@@ -1,12 +1,31 @@
 defmodule SnitchApiWeb.TaxonomyControllerTest do
   use SnitchApiWeb.ConnCase, async: true
 
+  import Snitch.Factory
+
+  alias Snitch.Data.Schema.Role
+  alias Snitch.Repo
+  alias SnitchApi.Accounts
+
   setup %{conn: conn} do
+    user = build(:user_with_no_role)
+    role = build(:role, name: "user")
+
+    Repo.insert(role, on_conflict: :nothing)
+
+    {:ok, registered_user} = Accounts.create_user(user)
+
+    # create the token
+    {:ok, token, _claims} = SnitchApi.Guardian.encode_and_sign(registered_user)
+
+    # add authorization header to request
     conn =
       conn
       |> put_req_header("accept", "application/vnd.api+json")
       |> put_req_header("content-type", "application/vnd.api+json")
+      |> put_req_header("authorization", "Bearer #{token}")
 
+    # pass the connection and the user to the test
     {:ok, conn: conn}
   end
 

--- a/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
@@ -1,0 +1,93 @@
+defmodule SnitchApiWeb.UserControllerTest do
+  use SnitchApiWeb.ConnCase, async: true
+
+  import Snitch.Factory
+
+  alias SnitchApi.Accounts
+  alias Snitch.Repo
+
+  @invalid_attrs %{email: nil, password: nil}
+
+  setup %{conn: conn} do
+    user = build(:user_with_no_role)
+    role = build(:role, name: "user")
+
+    Repo.insert(role, on_conflict: :nothing)
+
+    user = %{
+      "data" => %{
+        "attributes" => user
+      }
+    }
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "User Registration" do
+    test "creation and sign in with valid data", %{conn: conn, user: user} do
+      conn = post(conn, user_path(conn, :create), user)
+      assert %{"id" => id} = json_response(conn, 200)["data"]
+
+      conn =
+        post(
+          conn,
+          user_path(conn, :login, user)
+        )
+
+      assert json_response(conn, 200)["token"]
+    end
+
+    test "render errors when data is invalid", %{conn: conn} do
+      conn = post(conn, user_path(conn, :create), user: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "login with empty parameters", %{conn: conn} do
+      conn = post(conn, user_path(conn, :login))
+      assert json_response(conn, 404)["errors"] == %{"detail" => "no login credentials"}
+    end
+
+    test "missing parameter in user registration", %{conn: conn} do
+      user = %{
+        "data" => %{
+          "attributes" => build(:user_with_no_role) |> Map.delete("email")
+        }
+      }
+
+      conn = post(conn, user_path(conn, :create), user)
+      assert json_response(conn, 422)["errors"] == %{"email" => ["can't be blank"]}
+    end
+  end
+
+  describe "Authenticated routing" do
+    setup %{conn: conn, user: user} do
+      user = JaSerializer.Params.to_attributes(user)
+      {:ok, registered_user} = Accounts.create_user(user)
+
+      # create the token
+      {:ok, token, _claims} = SnitchApi.Guardian.encode_and_sign(registered_user)
+
+      # add authorization header to request
+      conn = conn |> put_req_header("authorization", "Bearer #{token}")
+
+      # pass the connection and the user to the test
+      {:ok, conn: conn, user: registered_user}
+    end
+
+    test "fetching logged in user", %{conn: conn, user: user} do
+      conn = get(conn, user_path(conn, :current_user))
+
+      assert Map.get(user, :id) == json_response(conn, 200)["data"]["id"]
+    end
+
+    test "logging out user", %{conn: conn} do
+      conn = post(conn, user_path(conn, :logout))
+      assert %{"status" => "logged out"} = json_response(conn, 204)
+    end
+  end
+end

--- a/apps/snitch_api/test/snitch_api_web/plugs/load_user_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/plugs/load_user_test.exs
@@ -1,0 +1,49 @@
+defmodule SnitchApiWeb.Plugs.LoadUser do
+  use SnitchApiWeb.ConnCase, async: true
+
+  import Snitch.Factory
+
+  alias Snitch.Repo
+  alias SnitchApi.Accounts
+  alias SnitchApiWeb.Plug.LoadUser
+
+  setup %{conn: conn} do
+    role = build(:role, name: "user")
+    Repo.insert(role, on_conflict: :nothing)
+
+    user = %{
+      "data" => %{
+        "attributes" => build(:user_with_no_role)
+      }
+    }
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "Loading User" do
+    test "when user is not signin", %{conn: conn} do
+      conn = LoadUser.call(conn, %{})
+      assert nil == conn.assigns[:current_user]
+    end
+
+    test "when user in signed in", %{conn: conn, user: user} do
+      user = JaSerializer.Params.to_attributes(user)
+      {:ok, registered_user} = Accounts.create_user(user)
+
+      # create the token
+      {:ok, token, _claims} = SnitchApi.Guardian.encode_and_sign(registered_user)
+
+      # add authorization header to request
+      conn = conn |> put_req_header("authorization", "Bearer #{token}")
+      conn = get(conn, order_path(conn, :index))
+      conn = LoadUser.call(conn, %{})
+
+      assert user["email"] == Map.get(conn.assigns[:current_user], :email)
+    end
+  end
+end

--- a/apps/snitch_api/test/snitch_api_web/views/error_view_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/views/error_view_test.exs
@@ -4,18 +4,18 @@ defmodule SnitchApiWeb.ErrorViewTest do
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View
 
-  test "renders 404.json" do
-    assert render(SnitchApiWeb.ErrorView, "404.json", []) ==
+  test "renders 404.json-api" do
+    assert render(SnitchApiWeb.ErrorView, "404.json-api", []) ==
              %{errors: %{detail: "Page not found"}}
   end
 
-  test "render 500.json" do
-    assert render(SnitchApiWeb.ErrorView, "500.json", []) ==
+  test "render 500.json-api" do
+    assert render(SnitchApiWeb.ErrorView, "500.json-api", []) ==
              %{errors: %{detail: "Internal server error"}}
   end
 
   test "render any other" do
-    assert render(SnitchApiWeb.ErrorView, "505.json", []) ==
+    assert render(SnitchApiWeb.ErrorView, "505.json-api", []) ==
              %{errors: %{detail: "Internal server error"}}
   end
 end

--- a/apps/snitch_core/lib/core/data/model/role.ex
+++ b/apps/snitch_core/lib/core/data/model/role.ex
@@ -101,6 +101,14 @@ defmodule Snitch.Data.Model.Role do
   end
 
   @doc """
+  Returns the role for the given roll_name.
+  """
+  @spec get_role_by_name(string) :: Role.t()
+  def get_role_by_name(name) do
+    Repo.get_by!(Role, name: name)
+  end
+
+  @doc """
   Returns a list of roles in the format {role.name, role.id}
   """
   @spec formatted_list() :: [{String.t(), non_neg_integer}]

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -83,6 +83,7 @@ defmodule Snitch.Data.Schema.User do
   @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp common_changeset(user_changeset) do
     user_changeset
+    |> foreign_key_constraint(:role_id)
     |> validate_confirmation(:password)
     |> validate_length(:password, min: @password_min_length)
     |> validate_format(:email, ~r/@/)

--- a/apps/snitch_core/mix.exs
+++ b/apps/snitch_core/mix.exs
@@ -33,7 +33,7 @@ defmodule Snitch.Core.Mixfile do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support", "priv/repo/seed"]
   defp elixirc_paths(_), do: ["lib", "priv/repo/seed"]
 
   # Specifies your project dependencies.

--- a/apps/snitch_core/priv/repo/seed/country_state.ex
+++ b/apps/snitch_core/priv/repo/seed/country_state.ex
@@ -10,13 +10,13 @@ defmodule Snitch.Seed.CountryState do
 
   require Logger
 
-  def seed_countries! do
+  def seed_countries!() do
     countries = Enum.map(Country.fetch_all(), &to_country_params/1)
     {count, _} = Repo.insert_all(CountrySchema, countries, on_conflict: :nothing)
     Logger.info("Inserted #{count} countries.")
   end
 
-  def seed_states! do
+  def seed_states!() do
     query = from(CountrySchema, select: [:id, :iso])
 
     countries =

--- a/apps/snitch_core/test/data/schema/user_test.exs
+++ b/apps/snitch_core/test/data/schema/user_test.exs
@@ -3,6 +3,7 @@ defmodule Snitch.Data.Schema.UserTest do
   use Snitch.DataCase
 
   import Ecto.Changeset, only: [apply_changes: 1]
+  import Snitch.Factory
 
   alias Snitch.Data.Schema.User
 

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -36,6 +36,16 @@ defmodule Snitch.Factory do
     }
   end
 
+  def user_with_no_role_factory do
+    %{
+      "first_name" => sequence(:first_name, &"Snitch-#{&1}"),
+      "last_name" => sequence(:last_name, &"Elixir-#{&1}"),
+      "email" => sequence(:email, &"minion-#{&1}@snitch.com"),
+      "password" => "NOTASECRET",
+      "password_confirmation" => "NOTASECRET"
+    }
+  end
+
   def random_variant_factory do
     %Variant{
       sku: sequence(:sku, &"shoes-nike-#{&1}"),
@@ -149,8 +159,8 @@ defmodule Snitch.Factory do
 
   def role_factory do
     %Role{
-      name: "admin",
-      description: "can manage all"
+      name: sequence(:name, ["admin", "user"]),
+      description: sequence(:description, ["can manage all", "can manage few"])
     }
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "aruspex": {:git, "https://github.com/oyeb/aruspex.git", "5ca5ca6057b61b2bc19a58abd3a5a656c39d0249", [branch: "tweaks"]},
   "as_nested_set": {:git, "https://github.com/SagarKarwande/as_nested_set.git", "fb1f481dad83602eca68b7a8ca95cfca71075d25", []},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
+  "bcrypt_elixir": {:hex, :bcrypt_elixir, "1.0.7", "e79d84b666bfad0e461ed217860e1c7de6bc4a1ae919cdb39d473ca784817653", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "beepbop": {:git, "https://github.com/oyeb/beepbop.git", "221c04e597fda726b3d36c92603096e05787b46d", [branch: "develop"]},
   "blankable": {:hex, :blankable, "0.0.1", "2e0b4667fee684f0614620d31a34bb2731341cccb27ed903e330195819ba3ba0", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},


### PR DESCRIPTION
### User Authentication API 

Prior to this change, the user authentication and letting only
authorized users to access the API is not provided.

This change implements the user registration, sign in and sign out featured API

### Things covered
--------------
- API-user sign in
- API-user sign out
- API-user registration
- API-user-auth
- token generation
- route authentication
- mixed route plugs for auth routes and no auth routes
- API for current user
- test cases for Accounts and User control

-----------------

This PR delivers the following stories.

https://www.pivotaltracker.com/story/show/158870221
https://www.pivotaltracker.com/story/show/158870194

-------------------
[deliver #158870221]
[deliver #158870194]

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
