### PR TITLE
Api Authenticated User 158905043

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
@@ -56,7 +56,7 @@ defmodule SnitchApiWeb.UserController do
   end
 
   def authenticated(conn, _params) do
-    user = Guardian.Plug.current_resource(conn)
+    user = conn.assigns[:current_user]
     render(conn, "show.json-api", data: user)
   end
 end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
@@ -54,4 +54,9 @@ defmodule SnitchApiWeb.UserController do
     user = Guardian.Plug.current_resource(conn)
     render(conn, "current_user.json-api", data: user)
   end
+
+  def authenticated(conn, _params) do
+    user = Guardian.Plug.current_resource(conn)
+    render(conn, "show.json-api", data: user)
+  end
 end

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -25,6 +25,7 @@ defmodule SnitchApiWeb.Router do
 
     # user sign_in_out_up
     get("/users/:id", UserController, :show)
+    get("/authenticated", UserController, :authenticated)
     post("/logout", UserController, :logout)
     get("/current_user", UserController, :current_user)
     resources("/orders", OrderController, only: [:index, :show])

--- a/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
@@ -89,5 +89,10 @@ defmodule SnitchApiWeb.UserControllerTest do
       conn = post(conn, user_path(conn, :logout))
       assert %{"status" => "logged out"} = json_response(conn, 204)
     end
+
+    test "authenticated user details", %{conn: conn, user: user} do
+      conn = get(conn, user_path(conn, :authenticated))
+      assert json_response(conn, 200)["data"]
+    end
   end
 end

--- a/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/user_controller_test.exs
@@ -74,6 +74,7 @@ defmodule SnitchApiWeb.UserControllerTest do
 
       # add authorization header to request
       conn = conn |> put_req_header("authorization", "Bearer #{token}")
+      conn = Plug.Conn.assign(conn, :current_user, registered_user)
 
       # pass the connection and the user to the test
       {:ok, conn: conn, user: registered_user}


### PR DESCRIPTION
This would allow the front end to check for authentication
in the beginning and returns the user info.

This change creates an API get /authenticated provides the user info
in JSON API spec

Story Link:  https://www.pivotaltracker.com/story/show/158905043

[deliver #158905043]

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
