### PR TITLE
Fetching user existing order or creating new one

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -59,7 +59,7 @@ defmodule SnitchApiWeb.OrderController do
       |> Map.update!(:country_id, &String.to_integer/1)
       |> Map.update!(:state_id, &String.to_integer/1)
 
-    billIntegerIntegering_address =
+    billing_address =
       billing_address
       |> Map.update!(:country_id, &String.to_integer/1)
       |> Map.update!(:state_id, &String.to_integer/1)
@@ -81,5 +81,16 @@ defmodule SnitchApiWeb.OrderController do
         ]
       )
     end
+  end
+
+  def current(conn, _params) do
+    user_id = Map.get(conn.assigns[:current_user], :id)
+
+    {:ok, order} = OrderModel.user_order(user_id)
+
+    conn
+    |> put_status(200)
+    |> put_resp_header("location", order_path(conn, :show, order))
+    |> render("show.json-api", data: order)
   end
 end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -83,6 +83,20 @@ defmodule SnitchApiWeb.OrderController do
     end
   end
 
+  def fetch_guest_order(conn, %{"order_number" => order_number}) do
+    with %Order{} = order <- OrderModel.get(%{number: order_number}) do
+      conn
+      |> put_status(200)
+      |> put_resp_header("location", order_path(conn, :show, order))
+      |> render("show.json-api", data: order)
+    else
+      nil ->
+        conn
+        |> put_status(200)
+        |> render("empty.json-api", data: %{})
+    end
+  end
+
   def current(conn, _params) do
     user_id = Map.get(conn.assigns[:current_user], :id)
 

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -18,8 +18,12 @@ defmodule SnitchApiWeb.Router do
     post("/register", UserController, :create)
     post("/login", UserController, :login)
     post("/orders/blank", OrderController, :guest_order)
+<<<<<<< HEAD
     get("/variants/favorites", VariantController, :favorite_variants)
     resources("/products", ProductController, except: [:new, :edit], param: "product_slug")
+=======
+    get("/orders/:order_number", OrderController, :fetch_guest_order)
+>>>>>>> added route to get guest_order by order number
   end
 
   scope "/api/v1", SnitchApiWeb do

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -34,6 +34,7 @@ defmodule SnitchApiWeb.Router do
     resources("/orders", OrderController, only: [:index, :show])
     resources("/line_items", LineItemController, only: [:create, :update, :show])
     post("/orders/:id/select_address", OrderController, :select_address)
+    post("/orders/current", OrderController, :current)
     resources("/taxonomies", TaxonomyController, only: [:index, :show])
     resources("/taxons", TaxonController, only: [:index, :show])
     resources("/ratings", RatingController, only: [:index, :show])

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -18,12 +18,9 @@ defmodule SnitchApiWeb.Router do
     post("/register", UserController, :create)
     post("/login", UserController, :login)
     post("/orders/blank", OrderController, :guest_order)
-<<<<<<< HEAD
     get("/variants/favorites", VariantController, :favorite_variants)
     resources("/products", ProductController, except: [:new, :edit], param: "product_slug")
-=======
     get("/orders/:order_number", OrderController, :fetch_guest_order)
->>>>>>> added route to get guest_order by order number
   end
 
   scope "/api/v1", SnitchApiWeb do

--- a/apps/snitch_api/lib/snitch_api_web/views/order_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/order_view.ex
@@ -29,7 +29,6 @@ defmodule SnitchApiWeb.OrderView do
     |> Map.get(:line_items)
   end
 
-<<<<<<< HEAD
   def shipping_address(struct, conn) do
     struct
     |> Map.get(:shipping_address)
@@ -56,9 +55,9 @@ defmodule SnitchApiWeb.OrderView do
         |> Map.from_struct()
         |> Map.delete(:__meta__)
     end
-=======
+  end
+
   def render("empty.json-api", %{data: %{}}) do
     %{data: nil}
->>>>>>> added route to get guest_order by order number
   end
 end

--- a/apps/snitch_api/lib/snitch_api_web/views/order_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/order_view.ex
@@ -29,6 +29,7 @@ defmodule SnitchApiWeb.OrderView do
     |> Map.get(:line_items)
   end
 
+<<<<<<< HEAD
   def shipping_address(struct, conn) do
     struct
     |> Map.get(:shipping_address)
@@ -55,5 +56,9 @@ defmodule SnitchApiWeb.OrderView do
         |> Map.from_struct()
         |> Map.delete(:__meta__)
     end
+=======
+  def render("empty.json-api", %{data: %{}}) do
+    %{data: nil}
+>>>>>>> added route to get guest_order by order number
   end
 end

--- a/apps/snitch_api/test/snitch_api_web/controllers/order_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/order_controller_test.exs
@@ -100,4 +100,31 @@ defmodule SnitchApiWeb.OrderControllerTest do
       assert json_response(conn, 200)["data"]
     end
   end
+
+  describe "User Orders" do
+    setup %{conn: conn, user: user} do
+      user = JaSerializer.Params.to_attributes(user)
+      {:ok, registered_user} = Accounts.create_user(user)
+
+      # create the token
+      {:ok, token, _claims} = Guardian.encode_and_sign(registered_user)
+
+      # add authorization header to request
+      conn = put_req_header(conn, "authorization", "Bearer #{token}")
+
+      # pass the connection and the user to the test
+      {:ok, conn: conn, user: registered_user}
+    end
+
+    test "creating new", %{conn: conn, user: user} do
+      conn = post(conn, order_path(conn, :current))
+      assert json_response(conn, 200)["data"]
+    end
+
+    test "fetching existing order", %{conn: conn, user: %{id: user_id}} do
+      order = insert(:order, user_id: user_id)
+      conn = post(conn, order_path(conn, :current))
+      assert Integer.to_string(order.id) == json_response(conn, 200)["data"]["id"]
+    end
+  end
 end

--- a/apps/snitch_api/test/snitch_api_web/controllers/order_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/order_controller_test.exs
@@ -21,12 +21,17 @@ defmodule SnitchApiWeb.OrderControllerTest do
     {:ok, conn: conn, user: user}
   end
 
+<<<<<<< HEAD
   describe "un_authorized users accessing api" do
+=======
+  describe "Guest Orders" do
+>>>>>>> added route to get guest_order by order number
     test "Empty order creation for guest user", %{conn: conn} do
       conn = post(conn, order_path(conn, :guest_order))
       assert json_response(conn, 200)["data"]
     end
 
+<<<<<<< HEAD
     test "error on accessing orders api", %{conn: conn} do
       resp = get(conn, order_path(conn, :index))
       assert resp.status == 403
@@ -98,6 +103,21 @@ defmodule SnitchApiWeb.OrderControllerTest do
 
       conn = post(conn, order_path(conn, :select_address, order.id, params))
       assert json_response(conn, 200)["data"]
+=======
+    test "Fetching Guest Order matcing order number", %{conn: conn} do
+      conn = post(conn, order_path(conn, :guest_order))
+      order = json_response(conn, 200)["data"]
+
+      conn =
+        get(conn, order_path(conn, :fetch_guest_order, get_in(order, ["attributes", "number"])))
+
+      assert Map.get(order, "id") == json_response(conn, 200)["data"]["id"]
+    end
+
+    test "Fetching Guest Order non matching order number", %{conn: conn} do
+      conn = get(conn, order_path(conn, :fetch_guest_order, "i don't match"))
+      assert nil == json_response(conn, 200)["data"]
+>>>>>>> added route to get guest_order by order number
     end
   end
 

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -39,6 +39,21 @@ defmodule Snitch.Data.Model.Order do
     |> Repo.insert()
   end
 
+  def user_order(user_id) do
+    Order
+    |> Repo.get_by(user_id: user_id, state: "cart")
+    |> case do
+      nil ->
+        %Order{}
+        |> Order.create_guest_changeset(%{})
+        |> Ecto.Changeset.put_change(:user_id, user_id)
+        |> Repo.insert()
+
+      order ->
+        {:ok, order}
+    end
+  end
+
   @doc """
   Creates an order with supplied `params` and `line_items`.
 
@@ -84,7 +99,7 @@ defmodule Snitch.Data.Model.Order do
   ```
   order # this is the order you wish to update, and `:line_items` are preloaded
   line_items = Enum.reduce(order.line_items, [], fn x, acc ->
-    [%{id: x.id} | acc]
+  [%{id: x.id} | acc]
   end)
   params = %{} # All changes except line-items
   all_params = Map.put(params, :line_items, line_items)
@@ -116,11 +131,11 @@ defmodule Snitch.Data.Model.Order do
 
   ```
   line_items = [
-    %{id: 1, quantity: 42},        # updates quantity of first
-    %{id: 2}                       # retains second
-    %{variant_id: 4, quantity: 42} # adds a new line-item (no `:id`)
+  %{id: 1, quantity: 42},        # updates quantity of first
+  %{id: 2}                       # retains second
+  %{variant_id: 4, quantity: 42} # adds a new line-item (no `:id`)
   ]                                # since there is no mention of `id: 3`,
-                                   # it gets removed!
+  # it gets removed!
 
   params = %{line_items: line_items}
   {:ok, updated_order} = Snitch.Data.Model.Order.update(params, order)


### PR DESCRIPTION
Getting new order or finding existing one

Prior to this change, We need to fetch new/existing order
for a logged in user.

As an authenticated api end point, it will find or create an order for the user
and will send the created order as a response. The matching order is
fetched with parameters `user_id: user_id` and `state: "cart"`.

Things covered
--------------
- New api Post /orders/current
- Unit test cases

Story Link
https://www.pivotaltracker.com/story/show/158936968

[deliver #158936968]

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
