### PR TITLE
Fix taxonomy API for nested data

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
@@ -4,22 +4,15 @@ defmodule SnitchApiWeb.TaxonomyController do
   alias Snitch.Data.Schema.Taxonomy
   alias Snitch.Repo
 
+  alias Snitch.Domain.Taxonomy, as: TaxonomyDomain
+
   action_fallback(SnitchApiWeb.FallbackController)
   plug(SnitchApiWeb.Plug.DataToAttributes)
   plug(SnitchApiWeb.Plug.LoadUser)
 
   def index(conn, _params) do
-    taxonomies =
-      Taxonomy
-      |> Repo.all()
-      |> Repo.preload([:root])
-
-    render(
-      conn,
-      "index.json-api",
-      data: taxonomies,
-      opts: [include: "root"]
-    )
+    taxonomy = TaxonomyDomain.get_all_taxonomy()
+    json(conn, %{data: taxonomy})
   end
 
   def show(conn, %{"id" => id}) do

--- a/apps/snitch_core/lib/core/data/schema/taxanomy/taxonomy.ex
+++ b/apps/snitch_core/lib/core/data/schema/taxanomy/taxonomy.ex
@@ -8,6 +8,7 @@ defmodule Snitch.Data.Schema.Taxonomy do
 
   schema "snitch_taxonomies" do
     field(:name, :string)
+    field(:taxons, :any, virtual: true)
 
     belongs_to(:root, Taxon)
     timestamps()

--- a/apps/snitch_core/lib/core/domain/taxonomy/taxonomy.ex
+++ b/apps/snitch_core/lib/core/domain/taxonomy/taxonomy.ex
@@ -9,6 +9,7 @@ defmodule Snitch.Domain.Taxonomy do
   import AsNestedSet.Queriable, only: [dump_one: 2]
 
   alias Snitch.Data.Schema.{Taxon, Taxonomy}
+  alias Snitch.Tools.Helper.Taxonomy, as: Helper
 
   @doc """
   Adds child taxon to left, right or child of parent taxon.
@@ -93,5 +94,14 @@ defmodule Snitch.Domain.Taxonomy do
   """
   def get_taxonomy(name) do
     Repo.get_by(Taxonomy, name: name)
+  end
+
+  @spec get_all_taxonomy :: [map()]
+  def get_all_taxonomy do
+    Taxonomy
+    |> Repo.all()
+    |> Repo.preload(:root)
+    |> Enum.map(fn taxonomy -> %{taxonomy | taxons: dump_taxonomy(taxonomy.id)} end)
+    |> Enum.map(&Helper.convert_to_map/1)
   end
 end

--- a/apps/snitch_core/lib/core/tools/helpers/taxonomy.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/taxonomy.ex
@@ -55,4 +55,30 @@ defmodule Snitch.Tools.Helper.Taxonomy do
       create_taxon(taxon, root)
     end
   end
+
+  def convert_to_map(taxonomy) do
+    root = convert_taxon(taxonomy.taxons)
+
+    %{
+      id: taxonomy.id,
+      name: taxonomy.name,
+      root: root
+    }
+  end
+
+  def convert_taxon([]) do
+    []
+  end
+
+  def convert_taxon({taxon, children}) do
+    %{
+      id: taxon.id,
+      name: taxon.name,
+      pretty_name: "",
+      permlink: "",
+      parent_id: taxon.parent_id,
+      taxonomy_id: taxon.taxonomy_id,
+      taxons: Enum.map(children, &convert_taxon/1)
+    }
+  end
 end


### PR DESCRIPTION
Taxonomy API now returns nested data

## Motivation and Context
Taxonomy API was not returning the nested data as per the taxonomy hierarchy.

## Describe your changes
Used taxonomy domain to generate nested data.

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
